### PR TITLE
Use ring util to get content-type header

### DIFF
--- a/src/main/fulcro/server.clj
+++ b/src/main/fulcro/server.clj
@@ -10,6 +10,7 @@
     [om.next.server :as om]
     om.util
     [ring.util.response :as resp]
+    [ring.util.request :as req]
     [taoensso.timbre :as log]
     [fulcro.client.util :as util])
   (:import (clojure.lang ExceptionInfo)
@@ -109,7 +110,7 @@
     ret))
 
 (defn- transit-request? [request]
-  (if-let [type (:content-type request)]
+  (if-let [type (req/content-type request)]
     (let [mtch (re-find #"^application/transit\+(json|msgpack)" type)]
       [(not (empty? mtch)) (keyword (second mtch))])))
 


### PR DESCRIPTION
Ring spec compliance now that `:content-type` as a request parameter is [deprecated](https://github.com/ring-clojure/ring/blob/master/SPEC#L82).