### PR TITLE
Add invalid merge case query

### DIFF
--- a/docs/CheatSheet.adoc
+++ b/docs/CheatSheet.adoc
@@ -102,7 +102,7 @@ especially if you intend to use children.
 - Every component that has state has it's *own* query. The following are errors:
   - `(query [this] (om/get-query OtherComponent))`
   - `(query [this] [(om/get-query OtherComponent)])`
-  - `(query [this] (concat (om/get-query OtherComponent) (om/get-query AnotherComponent))`
+  - `(query [this] [{:some-join (concat (om/get-query OtherComponent) (om/get-query AnotherComponent))}]`
 - Every child's query is composed in using an "invented" join name in the parent:
   - `(query [this] [{:invented-join-prop (om/get-query Child)}])`
 - Queries compose all the way to a single Root

--- a/docs/CheatSheet.adoc
+++ b/docs/CheatSheet.adoc
@@ -102,6 +102,7 @@ especially if you intend to use children.
 - Every component that has state has it's *own* query. The following are errors:
   - `(query [this] (om/get-query OtherComponent))`
   - `(query [this] [(om/get-query OtherComponent)])`
+  - `(query [this] (concat (om/get-query OtherComponent) (om/get-query AnotherComponent))`
 - Every child's query is composed in using an "invented" join name in the parent:
   - `(query [this] [{:invented-join-prop (om/get-query Child)}])`
 - Queries compose all the way to a single Root


### PR DESCRIPTION
I think it can be useful to have an invalid example on concatenating queries, I have seen this being tried a couple of times in past (by myself included), having it here can clear this up for newcomers.