### PR TITLE
Add basis time don't add fields from query not present on props

### DIFF
--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -119,22 +119,23 @@
                        (apply concat (->> children first :children (map :children)))
                        children)]
         (-> (into props
-                  (map (fn [{:keys [key query] :as ast}]
-                         (let [x (get props key)
-                               ast (cond-> ast
-                                     ; add children on recursive query
-                                     (= '... query)
-                                     (assoc :children children)
+                  (comp
+                    (filter #(contains? props (:key %)))
+                    (map (fn [{:keys [key query] :as ast}]
+                           (let [x   (get props key)
+                                 ast (cond-> ast
+                                       (= '... query)
+                                       (assoc :children children)
 
-                                     (pos-int? query)
-                                     (assoc :children (mapv #(cond-> %
-                                                               (pos-int? (:query %))
-                                                               (update :query dec))
-                                                        children)))]
-                           [key
-                            (if (sequential? x)
-                              (mapv #(add-basis-time* ast % time) x)
-                              (add-basis-time* ast x time))])))
+                                       (pos-int? query)
+                                       (assoc :children (mapv #(cond-> %
+                                                                 (pos-int? (:query %))
+                                                                 (update :query dec))
+                                                          children)))]
+                             [key
+                              (if (sequential? x)
+                                (mapv #(add-basis-time* ast % time) x)
+                                (add-basis-time* ast x time))]))))
                   children)
             (vary-meta assoc ::time time)))
       (vary-meta props assoc ::time time))
@@ -150,8 +151,7 @@
                 (vary-meta ele assoc ::time time)
                 ele)) props))
   ([q props time]
-   (add-basis-time props time)
-   #_(add-basis-time* (query->ast q) props time)))
+   (add-basis-time* (query->ast q) props time)))
 
 (defn get-basis-time
   "Returns the basis time from the given props, or ::unset if not available."

--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -3303,7 +3303,7 @@
   (if-not (has-ident? component)
     (log/error "merge-component!: component must implement Ident. Merge skipped.")
     (let [ident          (get-ident component object-data)
-          reconciler     (if (contains? reconciler :reconciler) (:reconciler reconciler))
+          reconciler     (if (contains? reconciler :reconciler) (:reconciler reconciler) reconciler)
           state          (app-state reconciler)
           data-path-keys (->> named-parameters (partition 2) (map second) flatten (filter keyword?) set vec)
           {:keys [merge-data merge-query]} (preprocess-merge state component object-data)]

--- a/src/test/fulcro/client/primitives_spec.cljc
+++ b/src/test/fulcro/client/primitives_spec.cljc
@@ -31,7 +31,7 @@
         x))
     m))
 
-#_(specification "Add basis time" :focused
+(specification "Add basis time"
   (assertions
     "Add time information recursively"
     (-> (prim/add-basis-time {:hello {:world {:data 2}
@@ -58,8 +58,9 @@
                 ::time 10}
         ::time 10}
 
-    "Out of query data is kept entirely"
+    "Out of query data is kept as is"
     (prim/add-basis-time [{:hello [{:world [:item]}
+                                   :query-only
                                    {:multi [:x]}]}]
       {:hello {:world {:data 2
                        :item [{:nested {:deep "bar"}}]}


### PR DESCRIPTION
The problem was that `add-basis-time` was adding props that were present in the query, but no the `props` itself to the result. This PR fixes this problem. Also, I detected an error on `merge-component!`, the logic to get the reconciler was returning `nil` if you passed the `reconciler` directly (instead of the `app`). I tested the `cards.UI_router_as_list_with_item_editor/list-and-editor` and it's working with those changes, but you should double check just in case.

Closes #73 