### PR TITLE
Mutation merge target

### DIFF
--- a/src/demos/cards/card_ui.cljs
+++ b/src/demos/cards/card_ui.cljs
@@ -25,6 +25,7 @@
     cards.server-query-security
     cards.server-return-values-as-data-driven-mutation-joins
     cards.server-return-values-manually-merging
+    cards.server-return-values-targeting
     [fulcro.client.logging :as log]))
 
 (log/set-level :debug)

--- a/src/demos/cards/server.clj
+++ b/src/demos/cards/server.clj
@@ -16,6 +16,7 @@
             cards.server_query_security
             cards.server_return_values_as_data_driven_mutation_joins
             cards.server_return_values_manually_merging
+            cards.server-return-values-targeting
             cards.loading-data-targeting-entities
             [fulcro.client.impl.parser :as op]
             [fulcro.easy-server :as core]

--- a/src/demos/cards/server_return_values_targeting.cljc
+++ b/src/demos/cards/server_return_values_targeting.cljc
@@ -1,0 +1,90 @@
+(ns cards.server-return-values-targeting
+  (:require
+    #?@(:cljs [[devcards.core :as dc :refer-macros [defcard defcard-doc]]
+               [fulcro.client.cards :refer [defcard-fulcro]]])
+    [fulcro.client.dom :as dom]
+    [fulcro.client.primitives :as prim :refer [defsc]]
+    [fulcro.client.dom :as dom]
+    [cards.card-utils :refer [sleep]]
+    [fulcro.client.mutations :as m :refer [defmutation]]
+    [fulcro.server :as server]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; SERVER:
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+#?(:clj (def clj->js identity))
+
+(server/defmutation trigger-error [_]
+  (action [env]
+    {:error "something bad"}))
+
+(server/defmutation create-sibling [data]
+  (action [env]
+    (assoc data :db/id "new-item")))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; CLIENT:
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(declare Item Sibling)
+
+(defmutation trigger-error [_]
+  (remote [{:keys [ast ref]}]
+    (m/with-target ast (conj ref :op-call))))
+
+(defmutation create-sibling [_]
+  (remote [{:keys [ast ref state]}]
+    (-> ast
+        (m/returning state Sibling)
+        (m/with-target (conj ref :sibling)))))
+
+(defsc Sibling
+  [this {:keys [item/name]}]
+  {:ident [:sibling/by-id :db/id]
+   :query [:db/id :item/name]}
+  (dom/div nil
+    "I'm a sibling " (str name)))
+
+(def ui-sibling (prim/factory Sibling))
+
+(defsc Item [this {:keys [db/id op-call sibling]}]
+  {:query [:db/id :op-call {:sibling (prim/get-query Sibling)}]
+   :ident [:item/by-id :db/id]}
+  (dom/div #js {}
+    (if op-call
+      (dom/div nil
+        "Result: " (pr-str op-call))
+      (dom/div nil "Waiting for call"))
+
+
+
+    (dom/button #js {:onClick (fn [evt]
+                                (prim/transact! this `[(trigger-error {})]))}
+      "Trigger Error")
+    (if sibling
+      (ui-sibling sibling)
+      (dom/button #js {:onClick (fn [evt]
+                                  (prim/transact! this `[(create-sibling {:item/name "Foo"})]))}
+        "Create Sibling"))))
+
+(def ui-item (prim/factory Item {:keyfn :db/id}))
+
+(defsc Root [this {:keys [ui/react-key ui/root]}]
+  {:query         [:ui/react-key {:ui/root (prim/get-query Item)}]
+   :initial-state {:ui/root {}}}
+  (dom/div (clj->js {:key react-key})
+    "Item below"
+    (ui-item root)))
+
+#?(:cljs
+   (defcard-fulcro mutation-target
+     "# Demonstration
+
+     This shows how you can make the mutation result target a specific place, if you use just the with-params the raw
+     response will be placed on the given path as is. If you use in conjunction with returning, the ident for the
+     created entity will be place into the target path. This target accepts the same things a load target does."
+     Root
+     {}
+     {:inspect-data true
+      :fulcro       {}}))
+

--- a/src/main/fulcro/client/data_fetch.cljc
+++ b/src/main/fulcro/client/data_fetch.cljc
@@ -4,6 +4,7 @@
     [clojure.walk :refer [walk prewalk]]
     [fulcro.client.primitives :as prim]
     [fulcro.client.impl.data-fetch :as impl]
+    [fulcro.client.impl.data-targeting :as targeting]
     [fulcro.client.mutations :refer [mutate defmutation]]
     [fulcro.client.logging :as log]
     [fulcro.client.dom :as dom]
@@ -22,16 +23,16 @@
   impl/marker-table)
 
 (defn multiple-targets [& targets]
-  (with-meta (vec targets) {::impl/multiple-targets true}))
+  (apply targeting/multiple-targets targets))
 
 (defn prepend-to [target]
-  (with-meta target {::impl/prepend-target true}))
+  (targeting/prepend-to target))
 
 (defn append-to [target]
-  (with-meta target {::impl/append-target true}))
+  (targeting/append-to target))
 
 (defn replace-at [target]
-  (with-meta target {::impl/replace-target true}))
+  (targeting/replace-at target))
 
 (defn- computed-refresh
   "Computes the refresh for the load by ensuring the loaded data is on the

--- a/src/main/fulcro/client/impl/data_targeting.cljc
+++ b/src/main/fulcro/client/impl/data_targeting.cljc
@@ -1,0 +1,100 @@
+(ns fulcro.client.impl.data-targeting
+  (:require [clojure.set :as set]
+            [fulcro.util :as util]))
+
+(defn multiple-targets [& targets]
+  (with-meta (vec targets) {::multiple-targets true}))
+
+(defn prepend-to [target]
+  (with-meta target {::prepend-target true}))
+
+(defn append-to [target]
+  (with-meta target {::append-target true}))
+
+(defn replace-at [target]
+  (with-meta target {::replace-target true}))
+
+(defn replacement-target? [t] (-> t meta ::replace-target boolean))
+(defn prepend-target? [t] (-> t meta ::prepend-target boolean))
+(defn append-target? [t] (-> t meta ::append-target boolean))
+(defn multiple-targets? [t] (-> t meta ::multiple-targets boolean))
+
+(defn special-target? [target]
+  (boolean (seq (set/intersection (-> target meta keys) #{::replace-target ::append-target ::prepend-target ::multiple-targets}))))
+
+(defn integrate-ident
+  "Integrate an ident into any number of places in the app state. This function is safe to use within mutation
+  implementations as a general helper function.
+
+  The named parameters can be specified any number of times. They are:
+
+  - append:  A vector (path) to a list in your app state where this new object's ident should be appended. Will not append
+  the ident if that ident is already in the list.
+  - prepend: A vector (path) to a list in your app state where this new object's ident should be prepended. Will not append
+  the ident if that ident is already in the list.
+  - replace: A vector (path) to a specific location in app-state where this object's ident should be placed. Can target a to-one or to-many.
+   If the target is a vector element then that element must already exist in the vector."
+  [state ident & named-parameters]
+  {:pre [(map? state)]}
+  (let [actions (partition 2 named-parameters)]
+    (reduce (fn [state [command data-path]]
+              (let [already-has-ident-at-path? (fn [data-path] (some #(= % ident) (get-in state data-path)))]
+                (case command
+                  :prepend (if (already-has-ident-at-path? data-path)
+                             state
+                             (do
+                               (assert (vector? (get-in state data-path)) (str "Path " data-path " for prepend must target an app-state vector."))
+                               (update-in state data-path #(into [ident] %))))
+                  :append (if (already-has-ident-at-path? data-path)
+                            state
+                            (do
+                              (assert (vector? (get-in state data-path)) (str "Path " data-path " for append must target an app-state vector."))
+                              (update-in state data-path conj ident)))
+                  :replace (let [path-to-vector (butlast data-path)
+                                 to-many?       (and (seq path-to-vector) (vector? (get-in state path-to-vector)))
+                                 index          (last data-path)
+                                 vector         (get-in state path-to-vector)]
+                             (assert (vector? data-path) (str "Replacement path must be a vector. You passed: " data-path))
+                             (when to-many?
+                               (do
+                                 (assert (vector? vector) "Path for replacement must be a vector")
+                                 (assert (number? index) "Path for replacement must end in a vector index")
+                                 (assert (contains? vector index) (str "Target vector for replacement does not have an item at index " index))))
+                             (assoc-in state data-path ident))
+                  (throw (ex-info "Unknown post-op to merge-state!: " {:command command :arg data-path})))))
+            state actions)))
+
+(defn process-target
+  ([state source-path target] (process-target state source-path target true))
+  ([state source-path target remove-ok?]
+   {:pre [(vector? target)]}
+   (let [item-to-place (cond (util/ident? source-path) source-path
+                             (keyword? source-path) (get state source-path)
+                             :else (get-in state source-path))
+         many-idents?  (and (vector? item-to-place)
+                            (every? util/ident? item-to-place))]
+     (cond
+       (and (util/ident? source-path)
+            (not (special-target? target))) (-> state
+                                                (assoc-in target item-to-place))
+       (not (special-target? target)) (cond->
+                                        (assoc-in state target item-to-place)
+                                        remove-ok? (dissoc source-path))
+       (multiple-targets? target) (cond-> (reduce (fn [s t] (process-target s source-path t false)) state target)
+                                    (and (not (util/ident? source-path)) remove-ok?) (dissoc source-path))
+       (and many-idents? (special-target? target)) (let [state            (if remove-ok?
+                                                                            (dissoc state source-path)
+                                                                            state)
+                                                         target-has-many? (vector? (get-in state target))]
+                                                     (if target-has-many?
+                                                       (cond
+                                                         (prepend-target? target) (update-in state target (fn [v] (vec (concat item-to-place v))))
+                                                         (append-target? target) (update-in state target (fn [v] (vec (concat v item-to-place))))
+                                                         :else state)
+                                                       (assoc-in state target item-to-place)))
+       (special-target? target) (cond-> state
+                                  remove-ok? (dissoc source-path)
+                                  (prepend-target? target) (integrate-ident item-to-place :prepend target)
+                                  (append-target? target) (integrate-ident item-to-place :append target)
+                                  (replacement-target? target) (integrate-ident item-to-place :replace target))
+       :else state))))

--- a/src/test/fulcro/client/data_fetch_spec.cljc
+++ b/src/test/fulcro/client/data_fetch_spec.cljc
@@ -700,45 +700,6 @@
       (dfi/split-items-ready-to-load [q-ab-x q-bc-x q-cd-x q-de-x]) => [[q-ab-x q-cd-x] [q-bc-x q-de-x]]
       (dfi/split-items-ready-to-load [q-bc-x q-de-x]) => [[q-bc-x q-de-x] []])))
 
-(specification "Special targeting"
-  (assertions
-    "Is detectable"
-    (dfi/special-target? (df/append-to [])) => true
-    (dfi/special-target? (df/prepend-to [])) => true
-    (dfi/special-target? (df/replace-at [])) => true
-    (dfi/special-target? (df/multiple-targets [:a] [:b])) => true)
-  (component "process-target"
-    (let [starting-state      {:root/thing [:y 2]
-                               :table      {1 {:id 1 :thing [:x 1]}}}
-          starting-state-many {:root/thing [[:y 2]]
-                               :table      {1 {:id 1 :things [[:x 1] [:x 2]]}}}]
-      (component "non-special targets"
-        (assertions
-          "moves an ident at some top-level key to an arbitrary path (non-special)"
-          (dfi/process-target starting-state :root/thing [:table 1 :thing]) => {:table {1 {:id 1 :thing [:y 2]}}}
-          "creates an ident for some location at a target location (non-special)"
-          (dfi/process-target starting-state [:table 1] [:root/thing]) => {:root/thing [:table 1]
-                                                                           :table      {1 {:id 1 :thing [:x 1]}}}
-          "replaces a to-many with a to-many (non-special)"
-          (dfi/process-target starting-state-many :root/thing [:table 1 :things]) => {:table {1 {:id 1 :things [[:y 2]]}}}))
-      (component "special targets"
-        (assertions
-          "can prepend into a to-many"
-          (dfi/process-target starting-state-many :root/thing (df/prepend-to [:table 1 :things])) => {:table {1 {:id 1 :things [[:y 2] [:x 1] [:x 2]]}}}
-          "can append into a to-many"
-          (dfi/process-target starting-state-many :root/thing (df/append-to [:table 1 :things])) => {:table {1 {:id 1 :things [[:x 1] [:x 2] [:y 2]]}}}
-          ; Unsupported:
-          ;"can replace an element in a to-many"
-          ;(df/process-target starting-state-many :root/thing (df/replace-at [:table 1 :things 0])) => {:table {1 {:id 1 :things [[:y 2] [:x 2]]}}}
-          "can affect multiple targets"
-          (dfi/process-target starting-state-many :root/thing (df/multiple-targets
-                                                                (df/prepend-to [:table 1 :stuff])
-                                                                [:root/spot]
-                                                                (df/append-to [:table 1 :things]))) => {:root/spot [[:y 2]]
-                                                                                                        :table     {1 {:id     1
-                                                                                                                       :stuff  [[:y 2]]
-                                                                                                                       :things [[:x 1] [:x 2] [:y 2]]}}})))))
-
 (specification "is-deferred-transaction?"
   (assertions
     "Returns false for invalid or nil queries"

--- a/src/test/fulcro/client/impl/data_targeting_spec.cljc
+++ b/src/test/fulcro/client/impl/data_targeting_spec.cljc
@@ -1,0 +1,50 @@
+(ns fulcro.client.impl.data-targeting-spec
+  (:require
+    [fulcro.client.impl.data-targeting :as targeting]
+    [fulcro-spec.core :refer
+     [specification behavior assertions provided component when-mocking]]))
+
+(specification "Special targeting"
+  (assertions
+    "Is detectable"
+    (targeting/special-target? (targeting/append-to [])) => true
+    (targeting/special-target? (targeting/prepend-to [])) => true
+    (targeting/special-target? (targeting/replace-at [])) => true
+    (targeting/special-target? (targeting/multiple-targets [:a] [:b])) => true)
+  (component "process-target"
+    (let [starting-state      {:root/thing [:y 2]
+                               :table      {1 {:id 1 :thing [:x 1]}}}
+          starting-state-many {:root/thing [[:y 2]]
+                               :table      {1 {:id 1 :things [[:x 1] [:x 2]]}}}
+          starting-state-data {:root/thing {:some "data"}
+                               :table      {1 {:id 1 :things [{:foo "bar"}]}}}]
+      (component "non-special targets"
+        (assertions
+          "moves an ident at some top-level key to an arbitrary path (non-special)"
+          (targeting/process-target starting-state :root/thing [:table 1 :thing]) => {:table {1 {:id 1 :thing [:y 2]}}}
+          "creates an ident for some location at a target location (non-special)"
+          (targeting/process-target starting-state [:table 1] [:root/thing]) => {:root/thing [:table 1]
+                                                                           :table      {1 {:id 1 :thing [:x 1]}}}
+          "replaces a to-many with a to-many (non-special)"
+          (targeting/process-target starting-state-many :root/thing [:table 1 :things]) => {:table {1 {:id 1 :things [[:y 2]]}}}))
+      (component "special targets"
+        (assertions
+          "can prepend into a to-many"
+          (targeting/process-target starting-state-many :root/thing (targeting/prepend-to [:table 1 :things])) => {:table {1 {:id 1 :things [[:y 2] [:x 1] [:x 2]]}}}
+          "can append into a to-many"
+          (targeting/process-target starting-state-many :root/thing (targeting/append-to [:table 1 :things])) => {:table {1 {:id 1 :things [[:x 1] [:x 2] [:y 2]]}}}
+          "keep data on db when remove-ok? is false"
+          (targeting/process-target starting-state-data :root/thing (targeting/prepend-to [:table 1 :things]) false)
+          => {:root/thing {:some "data"}
+              :table      {1 {:id 1 :things [{:some "data"} {:foo "bar"}]}}}
+          ; Unsupported:
+          ;"can replace an element in a to-many"
+          ;(targeting/process-target starting-state-many :root/thing (targeting/replace-at [:table 1 :things 0])) => {:table {1 {:id 1 :things [[:y 2] [:x 2]]}}}
+          "can affect multiple targets"
+          (targeting/process-target starting-state-many :root/thing (targeting/multiple-targets
+                                                                (targeting/prepend-to [:table 1 :stuff])
+                                                                [:root/spot]
+                                                                (targeting/append-to [:table 1 :things]))) => {:root/spot [[:y 2]]
+                                                                                                        :table     {1 {:id     1
+                                                                                                                       :stuff  [[:y 2]]
+                                                                                                                       :things [[:x 1] [:x 2] [:y 2]]}}})))))

--- a/src/test/fulcro/client/impl/parser_spec.cljc
+++ b/src/test/fulcro/client/impl/parser_spec.cljc
@@ -6,7 +6,88 @@
     [fulcro.client.dom :as dom]
     [fulcro.i18n :as i18n]
     [fulcro.client.impl.application :as app]
-    [fulcro.client.mutations :as m]))
+    [fulcro.client.mutations :as m]
+    [fulcro.test-helpers :as th]))
+
+(specification "query->ast"
+  (behavior "preserve meta"
+    (assertions
+      "don't add the :meta key when meta is absent"
+      (-> (prim/query->ast [:query])
+          (contains? :meta))
+      => false
+
+      "on query root"
+      (-> (prim/query->ast ^:marked [:query])
+          :meta)
+      => {:marked true}
+
+      "on joins"
+      (-> (prim/query->ast [^:marked {:join [:foo]}])
+          :children first :meta)
+      => {:marked true}
+
+      "on join subquery"
+      (-> (prim/query->ast [{:join ^:marked [:foo]}])
+          :children first :query meta)
+      => {:marked true}
+
+      "on calls"
+      (-> (prim/query->ast [(with-meta '(call {:x "y"}) {:marked true})])
+          :children first :meta)
+      => {:marked true})))
+
+(defn meta-round-trip [query]
+  (-> (prim/query->ast query)
+      (prim/ast->query)
+      (th/expand-meta)))
+
+(specification "meta persistence"
+  (behavior "keep meta on round trip"
+    (assertions
+      "on root"
+      (meta-round-trip ^:marked [:query])
+      => (th/expand-meta ^:marked [:query])
+
+      "on root with component"
+      (meta-round-trip ^{:marked true :component "X"} [:query])
+      => (th/expand-meta ^{:marked true :component "X"} [:query])
+
+      "on join"
+      (meta-round-trip [^:marked {:join [:foo]}])
+      => (th/expand-meta [^:marked {:join [:foo]}])
+
+      "on join query"
+      (meta-round-trip [{:join ^:marked [:foo]}])
+      => (th/expand-meta [{:join ^:marked [:foo]}])
+
+      "on calls"
+      (meta-round-trip [(with-meta '(call {:x "y"}) {:marked true})])
+      => (th/expand-meta [(with-meta '(call {:x "y"}) {:marked true})])
+
+      "on call joins"
+      (meta-round-trip [{'(call {:x "y"}) ^:mark ['*]}])
+      => (th/expand-meta [{'(call {:x "y"}) ^:mark ['*]}])
+
+      "on unions"
+      (meta-round-trip [^:marked {:union ^:marked {:a [:x] :b [:y]}}])
+      => (th/expand-meta [^:marked {:union ^:marked {:a [:x] :b [:y]}}])
+
+      "on recursion"
+      (meta-round-trip [:x :y {:children ^:marked '...}])
+      => (th/expand-meta [:x :y {:children ^:marked '...}])
+
+      "on a crazy example"
+      (meta-round-trip ^:marked [:x :y (with-meta 'a {:x 1})
+                                 ^:marked {^:marked [:ident 123] ^{:marked    true
+                                                                   :component "X"} [:query]}
+                                 {:join ^:mark [:lets ^:mark {:nested ^:marked [:query]}]}
+                                 ^:mark {:children ^:marked '...}])
+      => (th/expand-meta ^:marked [:x :y (with-meta 'a {:x 1})
+                                   ^:marked {^:marked [:ident 123] ^{:marked    true
+                                                                     :component "X"} [:query]}
+                                   {:join ^:mark [:lets ^:mark {:nested ^:marked [:query]}]}
+                                   ^:mark {:children ^:marked '...}]))))
 
 (m/defmutation sample-mutation-1 [params]
   (action [{:keys [state]}]

--- a/src/test/fulcro/test_helpers.cljc
+++ b/src/test/fulcro/test_helpers.cljc
@@ -1,0 +1,10 @@
+(ns fulcro.test-helpers
+  (:require [clojure.walk :as walk]))
+
+(defn expand-meta [f]
+  (walk/postwalk
+    (fn [x]
+      (if (meta x)
+        {::source x ::meta (meta x)}
+        x))
+    f))

--- a/src/test/fulcro/tests_to_run.cljs
+++ b/src/test/fulcro/tests_to_run.cljs
@@ -1,6 +1,7 @@
 (ns fulcro.tests-to-run
   (:require
     fulcro.client.impl.application-spec
+    fulcro.client.impl.data-targeting-spec
     fulcro.client.impl.parser-spec
     fulcro.client-spec
     fulcro.client.data-fetch-spec


### PR DESCRIPTION
This implements most of the things we discussed. Now the meta is fully preserved when round-tripping from `query->ast` / `ast->query`.  I added that `query->ast1` helper, was handy :)

Added the `with-target` as we discussed, I changed `returning` so the order of calls between `returning` and `with-target` doesn't matter, works both ways.

A basic `:replace` with the target is working, but not the other special target values, I got tired and left that for later, so you can help me with it :)

* [x] Finish the target support so it is consistent
* [x] Write a new demo that shows it working
* [x] Run all of the demos, todoMVC, template, and devguide against it to make sure there are no regressions. This touches some sensitive stuff.

Closes #66 