### PR TITLE
Persist the ref across all transactions in ptransact!

### DIFF
--- a/src/demos/cards/server_return_values_as_data_driven_mutation_joins.cljc
+++ b/src/demos/cards/server_return_values_as_data_driven_mutation_joins.cljc
@@ -87,7 +87,8 @@
     (dom/button #js {:onClick #(prim/ptransact! this `[(add-item {:list-id ~id
                                                                   :id      ~(prim/tempid)
                                                                   :value   "A New Value"})
-                                                       (set-overlay {:visible? false})])} "Add item")))
+                                                       (set-overlay {:visible? false})
+                                                       :overlay])} "Add item")))
 
 (def ui-list (prim/factory ItemList {:keyfn :db/id}))
 

--- a/src/main/fulcro/client/data_fetch.cljc
+++ b/src/main/fulcro/client/data_fetch.cljc
@@ -359,13 +359,13 @@
 (defmethod mutate 'fulcro/load [env _ params] (load* env params))
 (defmethod mutate `load [env _ params] (load* env params))
 
-(defmutation run-deferred-transaction [{:keys [tx reconciler]}]
+(defmutation run-deferred-transaction [{:keys [tx ref reconciler]}]
   (action [env]
     (let [reconciler (-> reconciler meta :reconciler)]
-      #?(:clj  (prim/transact! reconciler tx)
-         :cljs (js/setTimeout (fn [] (prim/transact! reconciler tx)) 1)))))
+      #?(:clj  (prim/transact! reconciler ref tx)
+         :cljs (js/setTimeout (fn [] (prim/transact! reconciler ref tx)) 1)))))
 
-(defmutation deferred-transaction [{:keys [tx remote]}]
+(defmutation deferred-transaction [{:keys [tx remote ref]}]
   (action [env]
     (let [{:keys [reconciler component] :as env} env
           reconciler (cond
@@ -377,6 +377,7 @@
                                                           :remote               remote
                                                           :marker               false
                                                           :post-mutation-params {:tx         tx
+                                                                                 :ref        ref
                                                                                  :reconciler (with-meta {} {:reconciler reconciler})}})
         (log/error (str "Cannot defer transaction. Reconciler was not available. Tx = " tx)))))
   (remote [env] (remote-load env)))

--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -2816,7 +2816,7 @@
   "Converts a sequence of calls as if each call should run in sequence (deferring even the optimistic side until
   the prior calls have completed in a full-stack manner), and returns a tx that can be submitted via the normal
   `transact!`."
-  [tx]
+  [ref tx]
   (let [ast-nodes     (:children (query->ast tx))
         {calls true reads false} (group-by #(= :call (:type %)) ast-nodes)
         first-call    (first calls)
@@ -2829,7 +2829,8 @@
     (if (seq (rest calls))
       (let [remaining-tx (ast->query {:type :root :children (into (vec (rest calls)) reads)})]
         (into tx-to-run-now `[(fulcro.client.data-fetch/deferred-transaction {:remote ~remote
-                                                                              :tx     ~(pessimistic-transaction->transaction remaining-tx)})]))
+                                                                              :ref    ~ref
+                                                                              :tx     ~(pessimistic-transaction->transaction ref remaining-tx)})]))
       tx-to-run-now)))
 
 (defn ptransact!
@@ -2841,8 +2842,9 @@
 
   NOTE: `ptransact!` *is* safe to use from within mutations (e.g. for retry behavior)."
   [comp-or-reconciler tx]
-  #?(:clj  (transact! comp-or-reconciler (pessimistic-transaction->transaction tx))
-     :cljs (js/setTimeout (fn [] (transact! comp-or-reconciler (pessimistic-transaction->transaction tx))) 0)))
+  (let [ref (if (component? comp-or-reconciler) (get-ident comp-or-reconciler))]
+    #?(:clj  (transact! comp-or-reconciler (pessimistic-transaction->transaction ref tx))
+       :cljs (js/setTimeout (fn [] (transact! comp-or-reconciler (pessimistic-transaction->transaction ref tx))) 0))))
 
 #?(:clj
    (defn- is-link? [query-element] (and (vector? query-element)

--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -2824,7 +2824,7 @@
         get-remote    (or (some-> (resolve 'fulcro.client.data-fetch/get-remote) deref) (fn [sym]
                                                                                           (log/error "FAILED TO FIND MUTATE. CANNOT DERIVE REMOTES FOR ptransact!")
                                                                                           :remote))
-        remote        (get-remote dispatch-key)
+        remote        (or (get-remote dispatch-key) :remote)
         tx-to-run-now (into [(ast->query first-call)] (ast->query {:type :root :children reads}))]
     (if (seq (rest calls))
       (let [remaining-tx (ast->query {:type :root :children (into (vec (rest calls)) reads)})]


### PR DESCRIPTION
When there is a series of transactions on `ptransact!`, the series of mutations will want to change the state at the level of the ident that triggered the error. While I was trying to write a generic error story I quickly realize that I would have to send the ref over and over, adding a lot of complexity on my code (might requiring macros to make something reusable across my components). This PR fixes that story by re-attaching the `ref` on the follow-up mutations after the first. I tested this change on a project of mine that uses and also with the mutation merge on demos.

Also fixes issue that prevents `ptransact!` to run the next mutation when the previous doesn't have a remote call.