### PR TITLE
fixed compiler hack by emitting calls to static methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Tweaks to docs and demos
 - DOM inputs (input, textarea, select, option) are now raw React elements
   - Use JVM option `-DwrappedInputs` on compile/figwheel JVM to get Legacy Om Next wrapped inputs.
+- Removed the cljs compiler hack for adv optimization. Fixed it in a way that is localized to Fulcro. This
+fixes the madness with needing a production profile to build adv builds!
+- Added support for `:initialize` option to load. Not documented yet.
 
 2.0.0-RC3
 ---------

--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -622,10 +622,11 @@
                                'js/undefined)
            static-methods    (gather-namespaced-protocol-calls statics)
            noop-static-calls (build-noop-static-calls name static-methods)
-           closure-fix       (when (seq noop-static-calls)
-                               `(try
-                                  ~@noop-static-calls
-                                  (catch :default ~'e)))]
+           closure-fix       (if (seq noop-static-calls)
+                               [`(try
+                                   ~@noop-static-calls
+                                   (catch :default ~'e))]
+                               [])]
        `(do
           ~ctor
           (specify! (.-prototype ~name) ~@(reshape dt reshape-map))
@@ -642,7 +643,7 @@
           (set! (.-cljs$lang$ctorPrWriter ~name)
             (fn [this# writer# opt#]
               (cljs.core/-write writer# ~(str fqn))))
-          ~closure-fix)))))
+          ~@closure-fix)))))
 
 (defmacro defui [name & forms]
   (if (boolean (:ns &env))

--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -590,7 +590,27 @@
                                  ~set-react-proto!))
            display-name     (if env
                               (str (-> env :ns :name) "/" name)
-                              'js/undefined)]
+                                       'js/undefined)
+           {static-methods :calls} (reduce (fn [{:keys [current-ns] :as acc} entry]
+                                             (cond
+                                               (and current-ns
+                                                 (list? entry)) (update acc :calls conj
+                                                                  (list (symbol current-ns (-> entry first clojure.core/name))
+                                                                    (rest entry)))
+                                               (list? entry) (update acc :calls conj entry)
+                                               (symbol? entry) (assoc acc :current-ns (namespace entry))
+                                               :else acc)) {:current-ns nil :calls []} (:protocols statics))
+           no-op-static-method-calls (map (fn [call]
+                                            (let [multi-arity? (list? (second call))
+                                                  nm           (first call)
+                                                  args         (if multi-arity?
+                                                                 (-> call second first)
+                                                                 (second call))
+                                                  arity        (count args)
+                                                  extra-args   (repeat (dec arity) nil)
+                                                  args         (cons name extra-args)
+                                                  noop-call    (cons nm args)]
+                                              noop-call)) static-methods)]
        `(do
           ~ctor
           (specify! (.-prototype ~name) ~@(reshape dt reshape-map))
@@ -608,7 +628,9 @@
             (fn [this# writer# opt#]
               (cljs.core/-write writer# ~(str fqn))))
           ;; TODO: here is where we could emit uses of the statics in a try/catch so the Closure will not collapse them
-          )))))
+          (try
+            ~@no-op-static-method-calls
+            (catch :default ~'e)))))))
 
 (defmacro defui [name & forms]
   (if (boolean (:ns &env))
@@ -619,7 +641,6 @@
   [& forms]
   (let [t (with-meta (gensym "ui_") {:anonymous true})]
     `(do (defui ~t ~@forms) ~t)))
-
 
 ;; =============================================================================
 ;; Globals & Dynamics
@@ -2749,64 +2770,6 @@
         (transact! reconciler tx)                           ; against reconciler, because we need to re-render from root
         (p/reindex! reconciler))
       (log/error "Unable to set query. Invalid arguments."))))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; DRAGONS BE HERE: The following code HACKS the cljs compiler to add an annotation so that
-; statics do not get removed from the defui components.
-; FIXME: It would be nice to figure out how to get this to work without the hack.
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-#?(:clj
-   (defn- add-proto-methods* [pprefix type type-sym [f & meths :as form]]
-     (let [pf          (str pprefix (name f))
-           emit-static (when (-> type-sym meta :static)
-                         `(~'js* "/** @nocollapse */"))]
-       (if (vector? (first meths))
-         ;; single method case
-         (let [meth meths]
-           [`(do
-               ~emit-static
-               (set! ~(#'cljs.core/extend-prefix type-sym (str pf "$arity$" (count (first meth))))
-                 ~(with-meta `(fn ~@(#'cljs.core/adapt-proto-params type meth)) (meta form))))])
-         (map (fn [[sig & body :as meth]]
-                `(do
-                   ~emit-static
-                   (set! ~(#'cljs.core/extend-prefix type-sym (str pf "$arity$" (count sig)))
-                     ~(with-meta `(fn ~(#'cljs.core/adapt-proto-params type meth)) (meta form)))))
-           meths)))))
-
-#?(:clj (intern 'cljs.core 'add-proto-methods* add-proto-methods*))
-
-#?(:clj
-   (defn- proto-assign-impls [env resolve type-sym type [p sigs]]
-     (#'cljs.core/warn-and-update-protocol p type env)
-     (let [psym        (resolve p)
-           pprefix     (#'cljs.core/protocol-prefix psym)
-           skip-flag   (set (-> type-sym meta :skip-protocol-flag))
-           static?     (-> p meta :static)
-           type-sym    (cond-> type-sym
-                         static? (vary-meta assoc :static true))
-           emit-static (when static?
-                         `(~'js* "/** @nocollapse */"))]
-       (if (= p 'Object)
-         (#'cljs.core/add-obj-methods type type-sym sigs)
-         (concat
-           (when-not (skip-flag psym)
-             (let [{:keys [major minor qualifier]} cljs.util/*clojurescript-version*]
-               (if (and (== major 1) (== minor 9) (>= qualifier 293))
-                 [`(do
-                     ~emit-static
-                     (set! ~(#'cljs.core/extend-prefix type-sym pprefix) cljs.core/PROTOCOL_SENTINEL))]
-                 [`(do
-                     ~emit-static
-                     (set! ~(#'cljs.core/extend-prefix type-sym pprefix) true))])))
-           (mapcat
-             (fn [sig]
-               (if (= psym 'cljs.core/IFn)
-                 (#'cljs.core/add-ifn-methods type type-sym sig)
-                 (#'cljs.core/add-proto-methods* pprefix type type-sym sig)))
-             sigs))))))
-
-#?(:clj (intern 'cljs.core 'proto-assign-impls proto-assign-impls))
 
 (defn pessimistic-transaction->transaction
   "Converts a sequence of calls as if each call should run in sequence (deferring even the optimistic side until

--- a/src/test/fulcro/client/primitives_spec.cljc
+++ b/src/test/fulcro/client/primitives_spec.cljc
@@ -1915,7 +1915,8 @@
     (prim/has-ident? AIdent) => true))
 
 #?(:clj (specification "defui advanced compile"
-          (assertions "Avoids removal of statics by calling all arities of them via the class"
+          (assertions
+            "Avoids removal of statics by calling all arities of them via the class"
             (last (prim/defui* 'Boo '(static prim/IQuery
                                        (query [this] [:a])
                                        (query [this arg] [:b])
@@ -1928,4 +1929,9 @@
                   (prim/query Boo nil)
                   (bah Boo nil nil)
                   (prim/ident Boo nil)
-                  (catch :default e)))))
+                  (catch :default e))
+
+            "Elides the try/catch where there are no static protocols"
+            (not= 'try (first (last (prim/defui* 'Boo '(Object
+                                                         (render [this] [:x 1])) nil))))
+            => true)))

--- a/src/test/fulcro/client/primitives_spec.cljc
+++ b/src/test/fulcro/client/primitives_spec.cljc
@@ -421,9 +421,7 @@
       (count (get @index-atom :u2)) => 1
       (count (get @index-atom :L)) => 1
       (count (get @index-atom :M)) => 1
-      (count (get @index-atom :union)) => 1
-
-      )))
+      (count (get @index-atom :union)) => 1)))
 
 (specification "remove-loads-and-fallbacks"
   (behavior "Removes top-level mutations that use the fulcro/load or tx/fallback symbols"
@@ -1916,3 +1914,18 @@
     (prim/has-ident? AState) => false
     (prim/has-ident? AIdent) => true))
 
+#?(:clj (specification "defui advanced compile"
+          (assertions "Avoids removal of statics by calling all arities of them via the class"
+            (last (prim/defui* 'Boo '(static prim/IQuery
+                                       (query [this] [:a])
+                                       (query [this arg] [:b])
+                                       static MyThing
+                                       (bah [this a b] :body)
+                                       static prim/Ident
+                                       (ident [this props] [:x 1])) nil))
+            => '(try
+                  (prim/query Boo)
+                  (prim/query Boo nil)
+                  (bah Boo nil nil)
+                  (prim/ident Boo nil)
+                  (catch :default e)))))


### PR DESCRIPTION
This should fix adv compile without the compiler hack...which pleases me greatly. The test shows what it does...basically it emits calls to all of the static methods in a try/catch at the end of the defui's code output. This allows Closure to see the calls in the context of the class, and should prevent it from removing them.

Advanced compile works with the dev guide with these fixes, so that bodes well.

I've tried to make sure these will work right with namespace aliasing and methods with more than one arity in protocols.

If anyone is willing to test this branch against their applications it would give me some more assurance that I've not missed anything.