### PR TITLE
Escape apostrophe in app-data

### DIFF
--- a/src/main/fulcro/server_render.cljc
+++ b/src/main/fulcro/server_render.cljc
@@ -9,7 +9,7 @@
    (defn initial-state->script-tag
      "Returns a string containing an HTML script tag that that sets js/window.INITIAL_APP_STATE to a transit-encoded string version of initial-state."
      [initial-state]
-     (let [assignment (str "window.INITIAL_APP_STATE = '" (util/transit-clj->str initial-state) "'")]
+     (let [assignment (str "window.INITIAL_APP_STATE = '" (clojure.string/replace (util/transit-clj->str initial-state) #"'" "\\\\'") "'")]
        (str
          "<script type='text/javascript'>\n"
          assignment

--- a/src/test/fulcro/server_render_spec.cljc
+++ b/src/test/fulcro/server_render_spec.cljc
@@ -47,6 +47,12 @@
        "puts an assignment on the document window"
        (ssr/initial-state->script-tag []) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = '[]'\n</script>\n")))
 
+#?(:clj
+   (specification "SSR script tag generation w/ apos"
+     (assertions
+       "puts an assignment on the document window with some tricky content"
+       (ssr/initial-state->script-tag {:some-field "some text's apostrophe"}) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = '[\"^ \",\"~:some-field\",\"some text\\'s apostrophe\"]'\n</script>\n")))
+
 #?(:cljs
    (specification "SSR initial-state extraction"
      (let [state (util/transit-clj->str [])]


### PR DESCRIPTION
Fixes a problem where an apostrophe in app-state closes SSR window.INITIAL_APP_STATE prematurely