### PR TITLE
Remove externs reference for which the file does not exist

### DIFF
--- a/src/main/deps.cljs
+++ b/src/main/deps.cljs
@@ -1,5 +1,4 @@
-{:externs ["fulcro/client/externs.js"]
- :foreign-libs
+{:foreign-libs
           [{:file     "yahoo/intl-messageformat-with-locales.js"
             :file-min "yahoo/intl-messageformat-with-locales.min.js"
             :provides ["yahoo.intl-messageformat-with-locales"]}]}


### PR DESCRIPTION
Removed externs reference because this breaks compilation with shadow-cljs which
will complain about the missing file in the jar.