### PR TITLE
Make app mount point id consistent.

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -203,7 +203,7 @@ The most basic HTML file you can start with (and it won't get much bigger) is:
 <!DOCTYPE html>
 <html>
     <body>
-        <div id="app-1"></div>
+        <div id="app"></div>
         <script src="js/app.js" type="text/javascript"></script>
     </body>
 </html>


### PR DESCRIPTION
The `mount` example directly above uses "app" as the mount point.