### PR TITLE
Check that attrs passed to dom fns are valid

### DIFF
--- a/src/main/fulcro/client/dom.cljc
+++ b/src/main/fulcro/client/dom.cljc
@@ -282,9 +282,14 @@
 
 #?(:clj (gen-react-dom-inline-fns))
 
+#?(:clj
+   (defn valid-opts? [opts]
+     (or (nil? opts) (map? opts))))
+
 (defn ^:private gen-react-dom-fn [tag]
   `(defn ~tag [opts# & children#]
      {:style/indent 1}
+     (assert (valid-opts? opts#) ~(str "first argument to " tag " must be either nil or a js object"))
      (.apply ~(symbol "js" "React.createElement") nil
        (cljs.core/into-array
          (cons ~(name tag) (cons opts# (cljs.core/map fulcro.util/force-children children#)))))))
@@ -302,6 +307,10 @@
     `(do
        ~@(clojure.core/map gen-react-dom-fn tags)
        ~@extra-inputs)))
+
+; (gen-react-dom-fn "link")
+
+
 
 ;; ===================================================================
 ;; Server-side rendering

--- a/src/main/fulcro/client/dom.cljs
+++ b/src/main/fulcro/client/dom.cljs
@@ -58,6 +58,9 @@
         (js/React.createElement element (.-state this))))
     (js/React.createFactory ctor)))
 
+(defn valid-opts? [opts]
+  (or (nil? opts) (object? opts)))
+
 (dom/gen-react-dom-fns)
 
 (defn render


### PR DESCRIPTION
Adds assertions to the dom functions to check if the attrs argument 
is valid.
The attrs are valid if they are `nil?` or `object?` (for cljs) or `map?` (for clj)
With this you get a stacktrace that includes the line where the invalid attr was passed, 
without this assert react will give you a warning, but not enough info to locate the where the error came from.