### PR TITLE
Made ws uri configurable and added transit handlers

### DIFF
--- a/src/main/fulcro/websockets.clj
+++ b/src/main/fulcro/websockets.clj
@@ -137,11 +137,12 @@
   The `wrap-api` function can be used to do that.
 
   If you don't supply a server adapter, it defaults to http-kit.
+  If you don't supply websockets-uri, it defaults to \"/chsk\".
   "
-  [parser websockets-uri {:keys [http-server-adapter transit-handlers sente-options]}]
+  [parser {:keys [websockets-uri http-server-adapter transit-handlers sente-options]}]
   (map->Websockets {:server-options   (merge {:user-id-fn (fn [r] (:client-id r))} sente-options)
                     :transit-handlers (or transit-handlers {})
-                    :websockets-uri   websockets-uri
+                    :websockets-uri   (or websockets-uri "/chsk")
                     :server-adapter   (or http-server-adapter (hk/get-sch-adapter))
                     :parser           parser}))
 

--- a/src/main/fulcro/websockets.cljs
+++ b/src/main/fulcro/websockets.cljs
@@ -14,7 +14,7 @@
       :api/server-push (when push-handler (push-handler ?data))
       (log/debug "Unsupported message " id))))
 
-(defrecord Websockets [channel-socket push-handler url host state-callback global-error-callback transit-handlers req-params stop app auto-retry?]
+(defrecord Websockets [channel-socket push-handler websockets-uri host state-callback global-error-callback transit-handlers req-params stop app auto-retry?]
   FulcroNetwork
   (send [this edn ok err]
     (let [{:keys [send-fn]} @channel-socket]
@@ -42,7 +42,7 @@
                 (err body)
                 (global-error-callback {:status 408 :body body}))))))))
   (start [this]
-    (let [{:keys [ch-recv state] :as cs} (sente/make-channel-socket! url ; path on server
+    (let [{:keys [ch-recv state] :as cs} (sente/make-channel-socket! websockets-uri ; path on server
                                            {:packer         (tp/make-packer transit-handlers)
                                             :host           host
                                             :type           :ws ; e/o #{:auto :ajax :ws}
@@ -64,7 +64,7 @@
   ALPHA QUALITY: Feel free to copy the source into your project and expand it as needed.
 
   Params:
-  - `url` - The url to handle websocket traffic on. (ex. \"/chsk\")
+  - `websockets-uri` - The uri to handle websocket traffic on. (ex. \"/chsk\", which is the default value)
   - `push-handler` - A function (fn [{:keys [topic msg]}] ...) that can handle a push message.
                      The topic is the server push verb, and the message will be the EDN sent.
   - `host` - Host option to send to sente
@@ -77,10 +77,10 @@
   - `auto-retry?` - A boolean (default false). If set to true any network disconnects will lead to infinite retries until
   the network returns. All remote mutations should be idempotent.
   "
-  [url & {:keys [global-error-callback push-handler host req-params state-callback transit-handlers auto-retry?]}]
+  [& {:keys [websockets-uri global-error-callback push-handler host req-params state-callback transit-handlers auto-retry?]}]
   (map->Websockets {:channel-socket        (atom nil)
                     :auto-retry?           auto-retry?
-                    :url                   url
+                    :websockets-uri        (or websockets-uri "/chsk")
                     :push-handler          push-handler
                     :host                  host
                     :state-callback        state-callback


### PR DESCRIPTION
Tested here https://github.com/fulcrologic/websockets2-demo/pull/2.

For https://github.com/fulcrologic/fulcro/issues/143

- Makes the socket uri configurable, client side was already configurable
- Adds a transit handlers options, consistent with what was available in the client side component
- Other sente events did not seem worth handling

**Potentially TODO**
- global-error-callback missing will throw an exception, when does this happen?
- auto-rety parameters...retry limit?, sente does an exponential back off for retries so maybe it's not needed?
- Messy code around API response handling (seems fine to me)