### PR TITLE
Remove data-fetch and routing dependencies on fulcro.client.dom

### DIFF
--- a/src/main/fulcro/client/data_fetch.cljc
+++ b/src/main/fulcro/client/data_fetch.cljc
@@ -7,7 +7,6 @@
     [fulcro.client.impl.data-targeting :as targeting]
     [fulcro.client.mutations :as m :refer [mutate defmutation]]
     [fulcro.logging :as log]
-    [fulcro.client.dom :as dom]
     [fulcro.client :as fc]
     [fulcro.util :as util]
     [clojure.set :as set]))
@@ -358,9 +357,9 @@
   (def ui-thing2 (prim/factory Thing2))
   ```"
   [data-render props & {:keys [ready-render loading-render failed-render not-present-render]
-                        :or   {loading-render (fn [_] (dom/div (clj->js {"className" "lazy-loading-load"}) "Loading..."))
-                               ready-render   (fn [_] (dom/div (clj->js {"className" "lazy-loading-ready"}) "Queued"))
-                               failed-render  (fn [_] (dom/div (clj->js {"className" "lazy-loading-failed"}) "Loading error!"))}}]
+                        :or   {loading-render (fn [_] "Loading...")
+                               ready-render   (fn [_] "Queued")
+                               failed-render  (fn [_] "Loading error!")}}]
 
   (let [state (:ui/fetch-state props)]
     (cond

--- a/src/main/fulcro/client/routing.cljc
+++ b/src/main/fulcro/client/routing.cljc
@@ -4,7 +4,6 @@
             [fulcro.client :as fc]
             [fulcro.client.primitives :as prim :refer [defui defsc]]
             [fulcro.client.impl.protocols :as p]
-            fulcro.client.dom
     #?(:cljs [cljs.loader :as loader])
       [fulcro.logging :as log]
       [fulcro.util :as util]
@@ -40,7 +39,7 @@
               (let [page# (first (fulcro.client.primitives/get-ident ~'this))]
                 (case page#
                   ~@render-stmt
-                  (fulcro.client.dom/div nil (str "Cannot route: Unknown Screen " page#)))))))
+                  (str "Cannot route: Unknown Screen " page#))))))
        (catch Exception e `(def ~sym (log/error "BROKEN ROUTER!"))))))
 
 #?(:clj


### PR DESCRIPTION
This allows for other React apps that don't use the dom to load these files (React Native)