### PR TITLE
added cond that allows for auto-conversion of clj maps as props

### DIFF
--- a/src/main/fulcro/client/dom.cljc
+++ b/src/main/fulcro/client/dom.cljc
@@ -287,7 +287,11 @@
      {:style/indent 1}
      (.apply ~(symbol "js" "React.createElement") nil
        (cljs.core/into-array
-         (cons ~(name tag) (cons opts# (cljs.core/map fulcro.util/force-children children#)))))))
+         (cons ~(name tag) (cons (cond
+                                   (or (cljs.core/nil? opts#) (cljs.core/object? opts#)) opts#
+                                   (cljs.core/map? opts#) (cljs.core/clj->js opts#)
+                                   :else (throw ~(str "Invalid props on " tag)))
+                             (cljs.core/map fulcro.util/force-children children#)))))))
 
 (defmacro ^:private gen-react-dom-fns []
   (let [raw-inputs?  (boolean (System/getProperty "rawInputs" nil))


### PR DESCRIPTION
Remaining work: The DOM inputs use wrapped-dom-input, which is a crazy bit of code intended to help with lost input. Turns out it is quite useful, but I still need to add the props conversion in the correct places.

The other problem with the wrapped inputs in that they don't support the new react refs correctly. If anyone wants to look into that, let me know.