### PR TITLE
Dom API V2 CSS Shorhand

### DIFF
--- a/src/cards/fulcro/democards/alpha/dom_cards.cljs
+++ b/src/cards/fulcro/democards/alpha/dom_cards.cljs
@@ -18,24 +18,26 @@
     (div {} "Attr is empty object")
     (div #js {} "Attr is empty js-object")
     (div {:className "foo"} "Attr adds css class")
-    (div {:style #js {:backgroundColor "red"}} "Attr has nested inline style")))
+    (div {:style {:backgroundColor "red"}} "Attr has nested inline style")))
 
 (defcard-fulcro attr-static-enumeration
   "These attrs can be reasoned about at compile time."
   AttrStatic)
 
 (defsc AttrSymbolic [this props]
-  (let [x          nil
-        y          {}
-        z          #js {}
-        klass-info {:className "foo"}
-        styles     #js {:backgroundColor "red"}]
+  (let [x             nil
+        y             {}
+        z             #js {}
+        klass-info    {:className "foo"}
+        styles        {:backgroundColor "red"}
+        symbolic-attr {:style {:backgroundColor "green"}}]
     (div
       (div x "Attr is nil")
       (div y "Attr is empty object")
       (div z "Attr is empty js-object")
       (div klass-info "Attr adds css class")
-      (div {:style styles} "Attr has nested inline style"))))
+      (div {:style styles} "Attr has nested inline symbolic style")
+      (div symbolic-attr "Attr has nested inline style and is all symbolic"))))
 
 (defcard-fulcro attr-symbolic-enumeration
   "Part or all of these attrs are symbolic and resolved at runtime."

--- a/src/cards/fulcro/democards/alpha/dom_cards.cljs
+++ b/src/cards/fulcro/democards/alpha/dom_cards.cljs
@@ -44,7 +44,8 @@
   AttrSymbolic)
 
 (defsc CssShorthand [this props]
-  (let [symbolic-attr {:style {:backgroundColor "yellow"}} ]
+  (let [x             nil
+        symbolic-attr {:style {:backgroundColor "yellow"}} ]
     (div
       (dom/style "#the-id {background-color: coral;}")
       (dom/style ".border-klass {border-style: solid;}")
@@ -55,6 +56,10 @@
         "Has a shorthand CSS for border class and pink color class in attrs")
       (div :.border-klass {:style {:backgroundColor "violet"}}
         "Has a shorthand CSS for border class and violet background inline styles")
+      (div :.border-klass x
+        "Has a shorthand CSS for border class and symbolic nil attrs")
+      (div :.border-klass nil
+        "Has a shorthand CSS for border class and nil attrs")
       (div :.border-klass symbolic-attr
         "Has a shorthand CSS for border class and yellow background symbolic inline styles"))))
 

--- a/src/cards/fulcro/democards/alpha/dom_cards.cljs
+++ b/src/cards/fulcro/democards/alpha/dom_cards.cljs
@@ -15,7 +15,7 @@
       (span "attrs missing with a child element 1,")
       (span " and a child element 2"))
     (div nil "Attr is nil")
-    (div {} "Attr is empty object")
+    (div {} "Attr is empty map")
     (div #js {} "Attr is empty js-object")
     (div {:className "foo"} "Attr adds css class")
     (div {:style {:backgroundColor "red"}} "Attr has nested inline style")))
@@ -33,7 +33,7 @@
         symbolic-attr {:style {:backgroundColor "green"}}]
     (div
       (div x "Attr is nil")
-      (div y "Attr is empty object")
+      (div y "Attr is empty map")
       (div z "Attr is empty js-object")
       (div klass-info "Attr adds css class")
       (div {:style styles} "Attr has nested inline symbolic style")
@@ -42,6 +42,25 @@
 (defcard-fulcro attr-symbolic-enumeration
   "Part or all of these attrs are symbolic and resolved at runtime."
   AttrSymbolic)
+
+(defsc CssShorthand [this props]
+  (let [symbolic-attr {:style {:backgroundColor "yellow"}} ]
+    (div
+      (dom/style "#the-id {background-color: coral;}")
+      (dom/style ".border-klass {border-style: solid;}")
+      (dom/style ".color-klass {background-color: pink;}")
+
+      (div :#the-id.border-klass "Has a shorthand CSS for border class and coral background id")
+      (div :.border-klass {:className "color-klass"}
+        "Has a shorthand CSS for border class and pink color class in attrs")
+      (div :.border-klass {:style {:backgroundColor "violet"}}
+        "Has a shorthand CSS for border class and violet background inline styles")
+      (div :.border-klass symbolic-attr
+        "Has a shorthand CSS for border class and yellow background symbolic inline styles"))))
+
+(defcard-fulcro css-shorthand
+  "These dom elements use the CSS id/class (both shorthand and in attrs) with style tags."
+  CssShorthand)
 
 (defsc Form [this {:keys [:db/id :form/value] :as props}]
   {:query             [:db/id :form/value]

--- a/src/main/fulcro/client/alpha/css_parser.clj
+++ b/src/main/fulcro/client/alpha/css_parser.clj
@@ -14,13 +14,13 @@
   "Parse CSS shorthand keyword and return map of id/classes.
 
   (parse :.klass3#some-id.klass1.klass2)
-  => {:id      \"some-id\"
-      :classes \"klass3 klass1 klass2\"}"
+  => {:id        \"some-id\"
+      :className \"klass3 klass1 klass2\"}"
   [k]
   (if k
-    (let [tokens (get-tokens k)
+    (let [tokens  (get-tokens k)
           id      (->> tokens (filter #(re-matches #"^#.*" %)) first)
           classes (->> tokens (filter #(re-matches #"^\..*" %)))]
-      {:id      (remove-separators id)
-       :classes (str/join " " (map remove-separators classes))})
+      {:id        (remove-separators id)
+       :className (str/join " " (map remove-separators classes))})
     {}))

--- a/src/main/fulcro/client/alpha/css_parser.clj
+++ b/src/main/fulcro/client/alpha/css_parser.clj
@@ -1,0 +1,26 @@
+(ns fulcro.client.alpha.css-parser
+  "Simple parser for the optional CSS shorthand in dom API.
+  Inspired by https://github.com/r0man/sablono"
+  (:require [clojure.string :as str]))
+
+(defn remove-separators [s]
+  (when s
+    (str/replace s #"^[.#]" "")))
+
+(defn get-tokens [k]
+  (re-seq #"[#.]?[^#.]+" (name k)))
+
+(defn parse
+  "Parse CSS shorthand keyword and return map of id/classes.
+
+  (parse :.klass3#some-id.klass1.klass2)
+  => {:id      \"some-id\"
+      :classes \"klass3 klass1 klass2\"}"
+  [k]
+  (if k
+    (let [tokens (get-tokens k)
+          id      (->> tokens (filter #(re-matches #"^#.*" %)) first)
+          classes (->> tokens (filter #(re-matches #"^\..*" %)))]
+      {:id      (remove-separators id)
+       :classes (str/join " " (map remove-separators classes))})
+    {}))

--- a/src/main/fulcro/client/alpha/dom.cljc
+++ b/src/main/fulcro/client/alpha/dom.cljc
@@ -709,13 +709,18 @@
                     m)))
 
 #?(:clj
-   (s/def ::dom-element-args (s/cat
-                              :css (s/? keyword?)
-                              :attrs (s/? (s/or :nil       nil?
-                                                :map       map?
-                                                :js-object #(instance? JSValue %)
-                                                :symbol    symbol?))
-                              :children (s/* any?))))
+   (s/def ::dom-element-args
+     (s/cat
+      :css (s/? keyword?)
+      :attrs (s/? (s/or :nil       nil?
+                        :map       map?
+                        :js-object #(instance? JSValue %)
+                        :symbol    symbol?))
+      :children (s/* (s/or :string string?
+                           :number number?
+                           :symbol symbol?
+                           :nil    nil?
+                           :list   list?)))))
 
 #?(:clj
    (defn merge-css [attr-map id classes]
@@ -734,6 +739,7 @@
               {attrs#    :attrs
                children# :children
                css#      :css} conformed-args#
+              children#        (mapv second children#)
 
               attrs-type#  (or (first attrs#) :nil) ; attrs omitted == nil
               attrs-value# (or (second attrs#) {})

--- a/src/main/fulcro/client/alpha/dom.cljs
+++ b/src/main/fulcro/client/alpha/dom.cljs
@@ -81,7 +81,7 @@
 ;; fallback if the macro didn't do this
 (defn macro-create-element
   ([type args] (macro-create-element type args {}))
-  ([type args css]
+  ([type args {:keys [id className] :as css}]
    (let [[head & tail] args]
      (cond
        (map? head)
@@ -91,24 +91,20 @@
 
        (nil? head)
        (macro-create-element*
-        ;; TODO add css
-        (doto #js [type nil]
+        (doto #js [type #js {:id id :className className}]
           (arr-append tail)))
 
        (element? head)
-       ;; TODO add css
        (macro-create-element*
-        (doto #js [type nil]
+        (doto #js [type #js {:id id :className className}]
           (arr-append args)))
 
        (object? head)
-       ;; TODO add css
        (macro-create-element*
         (doto #js [type head]
           (arr-append tail)))
 
        :else
-       ;; TODO add css
        (macro-create-element*
-        (doto #js [type nil]
+        (doto #js [type #js {:id id :className className}]
           (arr-append args)))))))

--- a/src/main/fulcro/client/alpha/dom.cljs
+++ b/src/main/fulcro/client/alpha/dom.cljs
@@ -70,31 +70,45 @@
 (defn arr-append [arr tail]
   (reduce arr-append* arr tail))
 
+(defn add-css [attr-map {:keys [id className]}]
+  (let [classes-in-map (or (:class attr-map)
+                           (:className attr-map))
+        id-in-map      (:id attr-map)]
+    (assoc attr-map
+           :className (str classes-in-map " " className)
+           :id (or id id-in-map))))
+
 ;; fallback if the macro didn't do this
-(defn macro-create-element [type args]
-  (let [[head & tail] args]
-    (cond
-      (map? head)
-      (macro-create-element*
-        (doto #js [type (convert-props head)]
+(defn macro-create-element
+  ([type args] (macro-create-element type args {}))
+  ([type args css]
+   (let [[head & tail] args]
+     (cond
+       (map? head)
+       (macro-create-element*
+        (doto #js [type (clj->js (add-css head css))]
           (arr-append tail)))
 
-      (nil? head)
-      (macro-create-element*
+       (nil? head)
+       (macro-create-element*
+        ;; TODO add css
         (doto #js [type nil]
           (arr-append tail)))
 
-      (element? head)
-      (macro-create-element*
+       (element? head)
+       ;; TODO add css
+       (macro-create-element*
         (doto #js [type nil]
           (arr-append args)))
 
-      (object? head)
-      (macro-create-element*
+       (object? head)
+       ;; TODO add css
+       (macro-create-element*
         (doto #js [type head]
           (arr-append tail)))
 
-      :else
-      (macro-create-element*
+       :else
+       ;; TODO add css
+       (macro-create-element*
         (doto #js [type nil]
-          (arr-append args))))))
+          (arr-append args)))))))


### PR DESCRIPTION
Still a work in progress but just wanted to push up what I had so far.

- Recursively convert map literals to js object at compile time
- Spec'd dom macro arguments
- Added CSS shorthand notation parsing

TODO
- More thorough and organized tests, there a lot of permutations possible
- Cleanup code
- Obvious compile-time/runtime errors for trying to use css shorthand with js object? Or allow that?