### PR TITLE
Fix typo in section 2.11.4

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -2160,7 +2160,7 @@ to specify which network to talk over:
 ```
                        :started-callback (fn [app]
 
-                                           (df/load app :posts Post {:remote :rest :target [:post-list/by-id :the-one :posts]})
+                                           (df/load app :posts root/Post {:remote :rest :target [:post-list/by-id :the-one :posts]})
 
                                            ... as before ...
 ```


### PR DESCRIPTION
Added missing namespace to sample code. Closes #169 .