### PR TITLE
Accept props as expressions on dom calls

### DIFF
--- a/src/cards/fulcro/democards/dom_cards.cljs
+++ b/src/cards/fulcro/democards/dom_cards.cljs
@@ -11,21 +11,26 @@
 (def fspan span)
 (def finput dom/input)
 
+(defn js-classname [name] #js {:className name})
+(defn bg-color-style [color] {:style {:backgroundColor color}})
+
 (defsc AttrStatic [this props]
-  (div
-    (dom/section
+  (div nil
+    (dom/section nil
       (dom/h4 "Macros")
       (div "Attr is missing with a string child")
       (->> "String threaded through multiple DOM elements with various args" (span :.x {:className "a"}) (span #js {}) (div :.z))
-      (div
+      (div nil
         (span "attrs missing with a child element 1,")
         (span " and a child element 2"))
       (div nil "Attr is nil")
       (div {} "Attr is empty map")
       (div #js {} "Attr is empty js-object")
       (div {:className "foo"} "Attr adds css class")
-      (div {:style {:backgroundColor "red"}} "Attr has nested inline style"))
-    (dom/section
+      (div {:style {:backgroundColor "red"}} "Attr has nested inline style")
+      (div (js-classname "foo") "Attr fn adds css class")
+      (div (bg-color-style "red") "Attr fn has nested inline style"))
+    (dom/section nil
       (dom/h4 "Functions")
       (fdiv "Attr is missing with a string child")
       (->> "String threaded through multiple DOM elements with various args" (span :.x {:className "a"}) (span #js {}) (div :.z))
@@ -36,7 +41,9 @@
       (fdiv {} "Attr is empty map")
       (fdiv #js {} "Attr is empty js-object")
       (fdiv {:className "foo"} "Attr adds css class")
-      (fdiv {:style {:backgroundColor "red"}} "Attr has nested inline style"))))
+      (fdiv {:style {:backgroundColor "red"}} "Attr has nested inline style")
+      (fdiv (js-classname "foo") "Attr fn adds css class")
+      (fdiv (bg-color-style "red") "Attr fn has nested inline style"))))
 
 (defcard-fulcro attr-static-enumeration
   "These attrs can be reasoned about at compile time."
@@ -49,8 +56,8 @@
         klass-info    {:className "foo"}
         styles        {:backgroundColor "red"}
         symbolic-attr {:style {:backgroundColor "green"}}]
-    (div
-      (dom/section
+    (div nil
+      (dom/section nil
         (dom/h4 "Macros")
         (div x "Attr is nil")
         (div y "Attr is empty map")
@@ -58,7 +65,7 @@
         (div klass-info "Attr adds css class")
         (div {:style styles} "Attr has nested inline symbolic style")
         (div symbolic-attr "Attr has nested inline style and is all symbolic"))
-      (dom/section
+      (dom/section nil
         (dom/h4 "Functions")
         (fdiv x "Attr is nil")
         (fdiv y "Attr is empty map")
@@ -74,11 +81,11 @@
 (defsc CssShorthand [this props]
   (let [x             nil
         symbolic-attr {:style {:backgroundColor "yellow"}}]
-    (div
+    (div nil
       (dom/style "#the-id {background-color: coral;}")
       (dom/style ".border-klass {border-style: solid;}")
       (dom/style ".color-klass {background-color: pink;}")
-      (dom/section
+      (dom/section nil
         (dom/h3 "Macros")
         (div :#the-id.border-klass "Has a shorthand CSS for border class and coral background id")
         (div :.border-klass {:className "color-klass"}
@@ -91,7 +98,7 @@
           "Has a shorthand CSS for border class and nil attrs")
         (div :.border-klass symbolic-attr
           "Has a shorthand CSS for border class and yellow background symbolic inline styles"))
-      (dom/section
+      (dom/section nil
         (dom/h3 "Functions")
         (fdiv :#the-id.border-klass "Has a shorthand CSS for border class and coral background id")
         (fdiv :.border-klass {:className "color-klass"}
@@ -166,7 +173,7 @@
 
 (defsc TextAreaTest [this props]
   {}
-  (dom/div
+  (dom/div {}
     (dom/textarea {:value "This is a text area"})))
 
 (defcard-fulcro wrapped-textarea
@@ -174,14 +181,12 @@
 
 (defsc SelectTest [this props]
   {}
-  (dom/div
-
+  (dom/div nil
     (dom/select {:value "c"}
       (dom/option {:value "a" :label "A"})
       (dom/option {:value "b" :label "B"})
       (dom/option {:value "c" :label "C"})
-      (dom/option {:value "d" :label "D"}))
-    ))
+      (dom/option {:value "d" :label "D"}))))
 
 (defcard-fulcro wrapped-select
   SelectTest)

--- a/src/cards/fulcro/democards/dom_cards.cljs
+++ b/src/cards/fulcro/democards/dom_cards.cljs
@@ -15,12 +15,12 @@
 (defn bg-color-style [color] {:style {:backgroundColor color}})
 
 (defsc AttrStatic [this props]
-  (div nil
-    (dom/section nil
+  (div
+    (dom/section
       (dom/h4 "Macros")
       (div "Attr is missing with a string child")
       (->> "String threaded through multiple DOM elements with various args" (span :.x {:className "a"}) (span #js {}) (div :.z))
-      (div nil
+      (div
         (span "attrs missing with a child element 1,")
         (span " and a child element 2"))
       (div nil "Attr is nil")
@@ -30,7 +30,7 @@
       (div {:style {:backgroundColor "red"}} "Attr has nested inline style")
       (div (js-classname "foo") "Attr fn adds css class")
       (div (bg-color-style "red") "Attr fn has nested inline style"))
-    (dom/section nil
+    (dom/section
       (dom/h4 "Functions")
       (fdiv "Attr is missing with a string child")
       (->> "String threaded through multiple DOM elements with various args" (span :.x {:className "a"}) (span #js {}) (div :.z))
@@ -56,8 +56,8 @@
         klass-info    {:className "foo"}
         styles        {:backgroundColor "red"}
         symbolic-attr {:style {:backgroundColor "green"}}]
-    (div nil
-      (dom/section nil
+    (div
+      (dom/section
         (dom/h4 "Macros")
         (div x "Attr is nil")
         (div y "Attr is empty map")
@@ -65,7 +65,7 @@
         (div klass-info "Attr adds css class")
         (div {:style styles} "Attr has nested inline symbolic style")
         (div symbolic-attr "Attr has nested inline style and is all symbolic"))
-      (dom/section nil
+      (dom/section
         (dom/h4 "Functions")
         (fdiv x "Attr is nil")
         (fdiv y "Attr is empty map")
@@ -81,11 +81,11 @@
 (defsc CssShorthand [this props]
   (let [x             nil
         symbolic-attr {:style {:backgroundColor "yellow"}}]
-    (div nil
+    (div
       (dom/style "#the-id {background-color: coral;}")
       (dom/style ".border-klass {border-style: solid;}")
       (dom/style ".color-klass {background-color: pink;}")
-      (dom/section nil
+      (dom/section
         (dom/h3 "Macros")
         (div :#the-id.border-klass "Has a shorthand CSS for border class and coral background id")
         (div :.border-klass {:className "color-klass"}
@@ -98,7 +98,7 @@
           "Has a shorthand CSS for border class and nil attrs")
         (div :.border-klass symbolic-attr
           "Has a shorthand CSS for border class and yellow background symbolic inline styles"))
-      (dom/section nil
+      (dom/section
         (dom/h3 "Functions")
         (fdiv :#the-id.border-klass "Has a shorthand CSS for border class and coral background id")
         (fdiv :.border-klass {:className "color-klass"}
@@ -173,7 +173,7 @@
 
 (defsc TextAreaTest [this props]
   {}
-  (dom/div {}
+  (dom/div
     (dom/textarea {:value "This is a text area"})))
 
 (defcard-fulcro wrapped-textarea
@@ -181,7 +181,7 @@
 
 (defsc SelectTest [this props]
   {}
-  (dom/div nil
+  (dom/div
     (dom/select {:value "c"}
       (dom/option {:value "a" :label "A"})
       (dom/option {:value "b" :label "B"})

--- a/src/cards/fulcro/democards/localized_dom_cards.cljs
+++ b/src/cards/fulcro/democards/localized_dom_cards.cljs
@@ -12,11 +12,11 @@
 (def finput dom/input)
 
 (defsc AttrStatic [this props]
-  (div {}
-    (dom/section {}
+  (div
+    (dom/section
       (dom/h4 "Macros")
       (div "Attr is missing with a string child")
-      (div {}
+      (div
         (span "attrs missing with a child element 1,")
         (span " and a child element 2"))
       (div nil "Attr is nil")
@@ -24,10 +24,10 @@
       (div #js {} "Attr is empty js-object")
       (div {:className "foo"} "Attr adds css class")
       (div {:style {:backgroundColor "red"}} "Attr has nested inline style"))
-    (dom/section {}
+    (dom/section
       (dom/h4 "Functions")
       (div "Attr is missing with a string child")
-      (fdiv {}
+      (fdiv
         (fspan "attrs missing with a child element 1,")
         (fspan " and a child element 2"))
       (fdiv nil "Attr is nil")
@@ -47,8 +47,8 @@
         klass-info    {:className "foo"}
         styles        {:backgroundColor "red"}
         symbolic-attr {:style {:backgroundColor "green"}}]
-    (div {}
-      (dom/section {}
+    (div
+      (dom/section
         (dom/h4 "Macros")
         (div x "Attr is nil")
         (div y "Attr is empty map")
@@ -56,7 +56,7 @@
         (div klass-info "Attr adds css class")
         (div {:style styles} "Attr has nested inline symbolic style")
         (div symbolic-attr "Attr has nested inline style and is all symbolic"))
-      (dom/section {}
+      (dom/section
         (dom/h4 "Functions")
         (fdiv x "Attr is nil")
         (fdiv y "Attr is empty map")
@@ -75,9 +75,9 @@
          [:.color-klass {:background-color :pink}]]}
   (let [x             nil
         symbolic-attr {:style {:backgroundColor "yellow"}}]
-    (div {}
+    (div
       (css/style-element CssShorthand)
-      (dom/section {}
+      (dom/section
         (dom/h4 "Macros")
         (div :#the-id.border-klass "choral bg with border. Via localized kw")
         (div :.border-klass {:className color-klass} "pink bg with border. via kw + className")
@@ -85,7 +85,7 @@
         (div :.border-klass x "white bg with border. Via kw + sym")
         (div :.border-klass nil "white bg with border. Via kw + nil")
         (div :.border-klass symbolic-attr "yellow bg with border. Via kw + sym with inline styles"))
-      (dom/section {}
+      (dom/section
         (dom/h4 "Functions")
         (fdiv :#the-id.border-klass "choral bg with border. Via localized kw")
         (fdiv :.border-klass {:className color-klass} "pink bg with border. via kw + className")
@@ -125,7 +125,7 @@
                    {:old-form (prim/get-query OldForm)}]
    :ident         [:wrapped-input-root/by-id :db/id]
    :initial-state {:db/id 1 :form {}}}
-  (dom/div nil
+  (dom/div
     (ui-form form)))
 
 (defsc OldWrappedInputRoot [this {:keys [db/id form]}]
@@ -133,7 +133,7 @@
                    {:form (prim/get-query OldForm)}]
    :ident         [:wrapped-input-root/by-id :db/id]
    :initial-state {:db/id 1 :form {}}}
-  (dom/div nil
+  (dom/div
     (ui-old-form form)))
 
 (defcard-fulcro wrapped-input-card-string-refs

--- a/src/cards/fulcro/democards/localized_dom_cards.cljs
+++ b/src/cards/fulcro/democards/localized_dom_cards.cljs
@@ -12,11 +12,11 @@
 (def finput dom/input)
 
 (defsc AttrStatic [this props]
-  (div
-    (dom/section
+  (div {}
+    (dom/section {}
       (dom/h4 "Macros")
       (div "Attr is missing with a string child")
-      (div
+      (div {}
         (span "attrs missing with a child element 1,")
         (span " and a child element 2"))
       (div nil "Attr is nil")
@@ -24,10 +24,10 @@
       (div #js {} "Attr is empty js-object")
       (div {:className "foo"} "Attr adds css class")
       (div {:style {:backgroundColor "red"}} "Attr has nested inline style"))
-    (dom/section
+    (dom/section {}
       (dom/h4 "Functions")
       (div "Attr is missing with a string child")
-      (fdiv
+      (fdiv {}
         (fspan "attrs missing with a child element 1,")
         (fspan " and a child element 2"))
       (fdiv nil "Attr is nil")
@@ -47,8 +47,8 @@
         klass-info    {:className "foo"}
         styles        {:backgroundColor "red"}
         symbolic-attr {:style {:backgroundColor "green"}}]
-    (div
-      (dom/section
+    (div {}
+      (dom/section {}
         (dom/h4 "Macros")
         (div x "Attr is nil")
         (div y "Attr is empty map")
@@ -56,7 +56,7 @@
         (div klass-info "Attr adds css class")
         (div {:style styles} "Attr has nested inline symbolic style")
         (div symbolic-attr "Attr has nested inline style and is all symbolic"))
-      (dom/section
+      (dom/section {}
         (dom/h4 "Functions")
         (fdiv x "Attr is nil")
         (fdiv y "Attr is empty map")
@@ -75,9 +75,9 @@
          [:.color-klass {:background-color :pink}]]}
   (let [x             nil
         symbolic-attr {:style {:backgroundColor "yellow"}}]
-    (div
+    (div {}
       (css/style-element CssShorthand)
-      (dom/section
+      (dom/section {}
         (dom/h4 "Macros")
         (div :#the-id.border-klass "choral bg with border. Via localized kw")
         (div :.border-klass {:className color-klass} "pink bg with border. via kw + className")
@@ -85,7 +85,7 @@
         (div :.border-klass x "white bg with border. Via kw + sym")
         (div :.border-klass nil "white bg with border. Via kw + nil")
         (div :.border-klass symbolic-attr "yellow bg with border. Via kw + sym with inline styles"))
-      (dom/section
+      (dom/section {}
         (dom/h4 "Functions")
         (fdiv :#the-id.border-klass "choral bg with border. Via localized kw")
         (fdiv :.border-klass {:className color-klass} "pink bg with border. via kw + className")
@@ -113,8 +113,8 @@
    :initial-state     {:db/id 1 :form/value 22}
    :componentDidMount (fn [] (when-let [e (dom/node this "thing")] (.focus e)))}
   (finput {:onChange #(m/set-string! this :form/value :event %)
-              :ref      "thing"
-              :value    value}))
+           :ref      "thing"
+           :value    value}))
 
 (def ui-form (prim/factory Form {:keyfn :db/id}))
 (def ui-old-form (prim/factory OldForm {:keyfn :db/id}))
@@ -125,7 +125,7 @@
                    {:old-form (prim/get-query OldForm)}]
    :ident         [:wrapped-input-root/by-id :db/id]
    :initial-state {:db/id 1 :form {}}}
-  (dom/div
+  (dom/div nil
     (ui-form form)))
 
 (defsc OldWrappedInputRoot [this {:keys [db/id form]}]
@@ -133,7 +133,7 @@
                    {:form (prim/get-query OldForm)}]
    :ident         [:wrapped-input-root/by-id :db/id]
    :initial-state {:db/id 1 :form {}}}
-  (dom/div
+  (dom/div nil
     (ui-old-form form)))
 
 (defcard-fulcro wrapped-input-card-string-refs

--- a/src/main/fulcro/client/alpha/dom.clj
+++ b/src/main/fulcro/client/alpha/dom.clj
@@ -33,7 +33,7 @@
                      :number number?
                      :symbol symbol?
                      :nil nil?
-                     :list seq?))))
+                     :list sequential?))))
 
 (defn clj-map->js-object
   "Recursively convert a map to a JS object. For use in macro expansion."

--- a/src/main/fulcro/client/alpha/dom.clj
+++ b/src/main/fulcro/client/alpha/dom.clj
@@ -27,6 +27,7 @@
                   :map ::map-of-literals
                   :runtime-map ::map-with-expr
                   :js-object #(instance? JSValue %)
+                  :expression list?
                   :symbol symbol?))
     :children (s/* (s/or :string string?
                      :number number?
@@ -84,7 +85,7 @@
         `(~create-element ~(JSValue. (into [str-tag-name attr-expr] children))))
 
 
-      :symbol
+      (:symbol :expression)
       `(fulcro.client.alpha.dom/macro-create-element
          ~str-tag-name ~(into [attrs-value] children) ~css)
 

--- a/src/main/fulcro/client/alpha/dom.cljs
+++ b/src/main/fulcro/client/alpha/dom.cljs
@@ -184,6 +184,10 @@
        (f (doto #js [type (cdom/add-kwprops-to-props #js {} csskw)]
             (arr-append tail)))
 
+       (element? head)
+       (f (doto #js [type (cdom/add-kwprops-to-props #js {} csskw)]
+            (arr-append args)))
+
        (object? head)
        (f (doto #js [type (cdom/add-kwprops-to-props head csskw)]
             (arr-append tail)))
@@ -191,10 +195,6 @@
        (map? head)
        (f (doto #js [type (clj->js (cdom/add-kwprops-to-props head csskw))]
             (arr-append tail)))
-
-       (element? head)
-       (f (doto #js [type (cdom/add-kwprops-to-props #js {} csskw)]
-            (arr-append args)))
 
        :else
        (f (doto #js [type (cdom/add-kwprops-to-props #js {} csskw)]

--- a/src/main/fulcro/client/alpha/dom.cljs
+++ b/src/main/fulcro/client/alpha/dom.cljs
@@ -35,7 +35,8 @@
     :children (s/* (s/or
                      :string string?
                      :number number?
-                     :collection #(or (vector? %) (seq? %))
+                     :collection #(or (vector? %) (seq? %) (array? %))
+                     :nil nil?
                      :element element?))))
 
 (defn render

--- a/src/main/fulcro/client/alpha/localized_dom.clj
+++ b/src/main/fulcro/client/alpha/localized_dom.clj
@@ -34,7 +34,7 @@
         `(fulcro.client.alpha.dom/macro-create-element*
            ~(JSValue. (into [str-tag-name attr-expr] children))))
 
-      :symbol
+      (:symbol :expression)
       `(fulcro.client.alpha.localized-dom/macro-create-element
          ~str-tag-name ~(into [attrs-value] children) ~css)
 

--- a/src/main/fulcro/client/alpha/localized_dom_server.clj
+++ b/src/main/fulcro/client/alpha/localized_dom_server.clj
@@ -25,6 +25,7 @@
                      :string string?
                      :number number?
                      :collection #(or (vector? %) (seq? %))
+                     :nil nil?
                      :element element?))))
 
 (defn gen-tag-fn [tag]

--- a/src/test/fulcro/client/alpha/dom_server_spec.clj
+++ b/src/test/fulcro/client/alpha/dom_server_spec.clj
@@ -3,7 +3,7 @@
     [fulcro-spec.core :refer [specification behavior assertions provided component when-mocking]]
     [fulcro.client.alpha.dom-server :as dom :refer [div p span render-to-str]]))
 
-(specification "Server-side Rendering"
+(specification "Server-side Rendering" :focused
   (assertions
     "Simple tag rendering"
     (render-to-str (div {} "Hello"))
@@ -29,7 +29,7 @@
                      (div :.a#1 {:className "b"})))
     => "<div class=\"a b\" id=\"1\" data-reactroot=\"\" data-reactid=\"1\" data-react-checksum=\"-213767666\"><p class=\"x\" data-reactid=\"2\"><span data-reactid=\"3\">PS2</span></p></div>"))
 
-(specification "DOM elements are usable as functions"
+(specification "DOM elements are usable as functions" :focused
   (provided "The correct SSR function is called."
     (dom/element opts) => (assertions
                             (:tag opts) => 'div)

--- a/src/test/fulcro/client/alpha/dom_spec.cljc
+++ b/src/test/fulcro/client/alpha/dom_spec.cljc
@@ -8,7 +8,7 @@
   #?(:clj
      (:import (cljs.tagged_literals JSValue))))
 
-(specification "Conversion of keywords to CSS IDs and Classes"
+(specification "Conversion of keywords to CSS IDs and Classes" :focused
   (assertions
     "classnames are given as a vector"
     (#'cdom/parse :.a) => {:classes ["a"]}
@@ -25,7 +25,7 @@
     (#'cdom/parse :a) =throws=> {:regex #"Invalid style"}
     (#'cdom/parse :.a#.j) =throws=> {:regex #"Invalid style"}))
 
-(specification "Combining keywords on CLJ(s) property maps"
+(specification "Combining keywords on CLJ(s) property maps" :focused
   (let [props         {:className "c1"}
         props-with-id {:id 1 :className "c1"}]
     (assertions
@@ -48,7 +48,7 @@
            (cdom/add-kwprops-to-props props :.a.some-class.other-class) => {:className "a some-class other-class c1"})))))
 
 #?(:cljs
-   (specification "Combining keywords on JS property maps"
+   (specification "Combining keywords on JS property maps" :focused
      (let [js-props         #js {:className "c1"}
            js-props-with-id #js {:id 1 :className "c1"}]
        (assertions

--- a/src/test/fulcro/client/alpha/dom_spec.cljc
+++ b/src/test/fulcro/client/alpha/dom_spec.cljc
@@ -88,7 +88,7 @@
        :else v)))
 
 #?(:clj
-   (specification "Macro processing"
+   (specification "Macro processing" :focused
      (assertions
        "kw + nil props converts to a runtime js obj"
        (jsvalue->map (#'dom/emit-tag "div" [:.a nil "Hello"]))
@@ -124,12 +124,16 @@
        (jsvalue->map (#'dom/emit-tag "div" [:.a 'props "Hello"]))
        => `(dom/macro-create-element "div" [~'props "Hello"] :.a)
 
+       "expression emits runtime conversion"
+       (jsvalue->map (#'dom/emit-tag "div" [:.a '(props-map) "Hello"]))
+       => `(dom/macro-create-element "div" [~'(props-map) "Hello"] :.a)
+
        "embedded code in props is passed through"
        (jsvalue->map (#'dom/emit-tag "div" [:.a '{:onClick (fn [] (do-it))} "Hello"]))
-       => `(dom/macro-create-element* {:jsvalue ["div" (cdom/add-kwprops-to-props {:jsvalue {:onClick (~'fn [] (~'do-it))}} :.a) "Hello"]}))))
+       => `(dom/macro-create-element* {:jsvalue ["div" (cdom/add-kwprops-to-props {:jsvalue {:onClick ~'(fn [] (do-it))}} :.a) "Hello"]}))))
 
 #?(:cljs
-   (specification "DOM Tag Macros (CLJS)"
+   (specification "DOM Tag Macros (CLJS)" :focused
      (provided "It is passed no arguments"
        (dom/macro-create-element* args) => (do
                                              (assertions
@@ -313,7 +317,7 @@
          (div :.a (p :.b "Hello"))))))
 
 #?(:cljs
-   (specification "DOM elements are usable as functions"
+   (specification "DOM elements are usable as functions" :focused
      (assertions
        "The functions exist and are defined as functions"
        (fn? div) => true

--- a/src/test/fulcro/client/alpha/localized_dom_spec.clj
+++ b/src/test/fulcro/client/alpha/localized_dom_spec.clj
@@ -23,6 +23,10 @@
 
        (fulcro.client.alpha.dom/render-to-str ((fulcro.client.primitives/factory ~component) {})))))
 
+(defn fn-props [] {:className "x"})
+(defn fn-js-props [] #js {:className "x"})
+(defn fn-nil-props [] nil)
+
 (defsc NoPropsComponent [this props] (ldom/div :.a#y "Hello"))
 (defsc NilPropsComponent [this props] (ldom/div :.a#y nil "Hello"))
 (defsc EmptyPropsComponent [this props] (ldom/div :.a#y {} "Hello"))
@@ -42,6 +46,9 @@
 (defsc SymbolicClassPropsComponent [this props] (let [props {:className "x"}] (ldom/div :.a#y props "Hello")))
 (defsc SymbolicClassJSPropsComponent [this props] (let [props #js {:className "x"}] (ldom/div :.a#y props "Hello")))
 (defsc SymbolicClassNilPropsComponent [this props] (let [props nil] (ldom/div :.a#y props "Hello")))
+(defsc ExprClassPropsComponent [this props] (ldom/div :.a#y (fn-props) "Hello"))
+(defsc ExprClassJSPropsComponent [this props] (ldom/div :.a#y (fn-js-props) "Hello"))
+(defsc ExprClassNilPropsComponent [this props] (ldom/div :.a#y (fn-nil-props) "Hello"))
 
 (defn jsvalue->map
   "Converts a data structure (recursively) that contains JSValues, replacing any JSValue with
@@ -113,4 +120,10 @@
     "js props as symbol"
     (render-component SymbolicClassJSPropsComponent) =fn=> #(str/includes? % " class=\"fulcro_client_alpha_localized-dom-spec_SymbolicClassJSPropsComponent__a x\" id=\"y\"")
     "nil props as symbol"
-    (render-component SymbolicClassNilPropsComponent) =fn=> #(str/includes? % " class=\"fulcro_client_alpha_localized-dom-spec_SymbolicClassNilPropsComponent__a\" id=\"y\" ")))
+    (render-component SymbolicClassNilPropsComponent) =fn=> #(str/includes? % " class=\"fulcro_client_alpha_localized-dom-spec_SymbolicClassNilPropsComponent__a\" id=\"y\" ")
+    "cljs props as expression"
+    (render-component ExprClassPropsComponent) =fn=> #(str/includes? % " class=\"fulcro_client_alpha_localized-dom-spec_ExprClassPropsComponent__a x\" id=\"y\"")
+    "js props as expression"
+    (render-component ExprClassJSPropsComponent) =fn=> #(str/includes? % " class=\"fulcro_client_alpha_localized-dom-spec_ExprClassJSPropsComponent__a x\" id=\"y\"")
+    "nil props as expression"
+    (render-component ExprClassNilPropsComponent) =fn=> #(str/includes? % " class=\"fulcro_client_alpha_localized-dom-spec_ExprClassNilPropsComponent__a\" id=\"y\" ")))

--- a/src/test/fulcro/client/alpha/localized_dom_spec.cljs
+++ b/src/test/fulcro/client/alpha/localized_dom_spec.cljs
@@ -29,7 +29,7 @@
 
 ;; NOTE: There are some pathological cases that I'm just not bothering to support. E.g. a #js {:fulcro-css.css/classes #js [:.a]} as props
 
-(specification "Contextual rendering with localized CSS"
+(specification "Contextual rendering with localized CSS" :focused
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed a style kw and no props:" NoPropsComponent "fulcro_client_alpha_localized-dom-spec_NoPropsComponent__a")
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed a style kw and nil props:" NilPropsComponent "fulcro_client_alpha_localized-dom-spec_NilPropsComponent__a")
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed a style kw and empty cljs props:" EmptyPropsComponent "fulcro_client_alpha_localized-dom-spec_EmptyPropsComponent__a")
@@ -43,10 +43,9 @@
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed a style kw and a nil binding for props" SymbolicClassNilPropsComponent "fulcro_client_alpha_localized-dom-spec_SymbolicClassNilPropsComponent__a")
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed a style kw with global marker:" ExtendedCSSComponent "fulcro_client_alpha_localized-dom-spec_ExtendedCSSComponent__a b x")
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed js props with class and ID:" NoKWComponent "x")
-  (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed cljjs props with class and ID:" NoKWCLJComponent "x")
+  (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed cljs props with class and ID:" NoKWCLJComponent "x")
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed props with css/classes:" DynamicClassesComponent "fulcro_client_alpha_localized-dom-spec_DynamicClassesComponent__a b")
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed props with symbolic css/classes:" DynamicSymClassesComponent "fulcro_client_alpha_localized-dom-spec_DynamicSymClassesComponent__a b")
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed symbolic props that have css/classes:" DynamicSymPropsComponent "fulcro_client_alpha_localized-dom-spec_DynamicSymPropsComponent__a b")
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed symbolic props that have css/classes:" DynamicSymPropsWithNilEntryComponent "b ")
   (fulcro.client.alpha.localized-dom-spec/check-kw-processing "It is passed symbolic props with css/classes and kw:" DynamicSymPropsWithKWComponent "fulcro_client_alpha_localized-dom-spec_DynamicSymPropsWithKWComponent__z x fulcro_client_alpha_localized-dom-spec_DynamicSymPropsWithKWComponent__a b"))
-

--- a/src/test/fulcro/client/primitives_spec.cljc
+++ b/src/test/fulcro/client/primitives_spec.cljc
@@ -253,7 +253,7 @@
       (prim/get-query ui-rootp (prim/normalize-query {} (prim/get-query ui-rootp {})))
       => '[:a ({:join [:x]} {:join-params 2}) ({:union {:u1 [(:L {:child-params 1})] :u2 [:M]}} {:union-params 3})])))
 
-(specification "get-query*" :focused
+(specification "get-query*"
   (assertions
     "Obtains the static query from a given class"
     (prim/get-query Q) => [:a :b]
@@ -284,7 +284,7 @@
         "without state (raw static query)"
         (prim/get-query Root) => [:a {:join [:x]} {:union {:u1 [:L] :u2 [:M]}}]))))
 
-(specification "Normalization" :focused
+(specification "Normalization"
   (let [query               (prim/get-query ui-root {})
         parameterized-query (prim/get-query ui-rootp {})
         state               (prim/normalize-query {} query)
@@ -295,7 +295,7 @@
       "Preserves the query when parameters are present"
       (prim/get-query ui-rootp state-parameterized) => parameterized-query)))
 
-(specification "Setting a query" :focused
+(specification "Setting a query"
   (let [query                       (prim/get-query ui-root {})
         parameterized-query         (prim/get-query ui-rootp {})
         state                       (prim/normalize-query {} query)


### PR DESCRIPTION
This PR makes the new dom helpers accept expressions as props for dom nodes. During the process I found some issues with some of the specs, in particular, the `::dom-element-args`, it wasn't accepting `nils` as elements (which are valid, and a common pattern for cases like: `(if something (component {}))`), it was also missing check for js arrays (which usually come from children).

With those changes, I could just replace all requires to use localized dom and it kept all working :)

#175 