### PR TITLE
Load focus

### DIFF
--- a/src/main/fulcro/client/impl/data_fetch.cljc
+++ b/src/main/fulcro/client/impl/data_fetch.cljc
@@ -302,7 +302,6 @@
                                              (update c :params merge new-params)
                                              c)) %)))
 
-
 (defn ready-state
   "Generate a ready-to-load state with all of the necessary details to do
   remoting and merging."

--- a/src/test/fulcro/client/data_fetch_spec.cljc
+++ b/src/test/fulcro/client/data_fetch_spec.cljc
@@ -147,7 +147,11 @@
            "true: load params get initial state for component"
            (:initialize params) => {:root/comp {:x 1 :child {:y 2}}}
            "a map: load params get that map as the initial state of the component"
-           (:initialize params-with-init-params) => {:root/comp {:z 42}})))))
+           (:initialize params-with-init-params) => {:root/comp {:z 42}})))
+     (behavior "can focus the query"
+       (assertions
+         (:query (df/load-params* {} [:item/by-id 1] Item {:focus [:name {:comments [:title]}]}))
+         => [{[:item/by-id 1] [:name {:comments [:title]}]}]))))
 
 (specification "Load auto-refresh"
   (component "computed-refresh"

--- a/src/test/fulcro/client/primitives_spec.cljc
+++ b/src/test/fulcro/client/primitives_spec.cljc
@@ -20,7 +20,8 @@
             [fulcro.client.impl.protocols :as p]
             [fulcro.util :as util]
             [clojure.walk :as walk]
-            [fulcro.ui.form-state :as f])
+            [fulcro.ui.form-state :as f]
+            [fulcro.test-helpers :as th])
   #?(:clj
      (:import (clojure.lang ExceptionInfo))))
 
@@ -2003,6 +2004,24 @@
     (prim/has-ident? A) => false
     (prim/has-ident? AState) => false
     (prim/has-ident? AIdent) => true))
+
+(specification "focus-query-expr" :focused
+  (assertions
+    (prim/focus-subquery [] []) => []
+    (prim/focus-subquery [:a :b :c] []) => []
+    (prim/focus-subquery [:a :b :c] [:d]) => []
+    (prim/focus-subquery [:a :b :c] [:a]) => [:a]
+    (prim/focus-subquery [:a :b :c] [:a :b]) => [:a :b]
+    (prim/focus-subquery [:a {:b [:d]}] [:a :b]) => [:a {:b [:d]}]
+    (prim/focus-subquery [:a {:b [:c :d]}] [:a {:b [:c]}]) => [:a {:b [:c]}]
+    (prim/focus-subquery [:a '({:b [:c :d]} {:param "value"})] [:a {:b [:c]}])
+    => [:a '({:b [:c]} {:param "value"})]
+
+    ; in union case, keys absent from focus will be pulled anyway, given ones will focus
+    (prim/focus-subquery [:a {:b {:c [:d :e]
+                                  :f [:g :h]}}]
+      [:a {:b {:f [:g]}}])
+    => [:a {:b {:c [:d :e] :f [:g]}}]))
 
 (specification "db->tree"
   (assertions

--- a/src/test/fulcro/client/primitives_spec.cljc
+++ b/src/test/fulcro/client/primitives_spec.cljc
@@ -2005,7 +2005,7 @@
     (prim/has-ident? AState) => false
     (prim/has-ident? AIdent) => true))
 
-(specification "focus-query-expr" :focused
+(specification "focus-query-expr"
   (assertions
     (prim/focus-subquery [] []) => []
     (prim/focus-subquery [:a :b :c] []) => []


### PR DESCRIPTION
This PR adds a `:focus` option to load. The focus will receive a subquery that will focus a part of the original query. This also introduces a new primitive `focus-subquery`, the `focus-query` can only focus a single path (a linear vector path), while `focus-subquery` can use a secondary query for the focusing, allowing more customization in a single input.