### PR TITLE
Added docstrings to generated dom macros/fns

### DIFF
--- a/src/main/fulcro/client/dom.clj
+++ b/src/main/fulcro/client/dom.clj
@@ -109,7 +109,8 @@
     (str "Syntax error at " file ":" line ". Unexpected input " unexpected-input)))
 
 (defn gen-dom-macro [emitter name]
-  `(defmacro ~name [& ~'args]
+  `(defmacro ~name ~(cdom/gen-docstring name true)
+     [& ~'args]
      (let [tag# ~(str name)]
        (try
          (~emitter tag# ~'args)
@@ -120,7 +121,8 @@
   `(do ~@(clojure.core/map (partial gen-dom-macro emitter) cdom/tags)))
 
 (defn- gen-client-dom-fn [create-element-symbol tag]
-  `(defn ~tag [& ~'args]
+  `(defn ~tag ~(cdom/gen-docstring tag true)
+     [& ~'args]
      (let [conformed-args# (util/conform! :fulcro.client.dom/dom-element-args ~'args) ; see CLJS file for spec
            {attrs#    :attrs
             children# :children

--- a/src/main/fulcro/client/dom_common.cljc
+++ b/src/main/fulcro/client/dom_common.cljc
@@ -63,4 +63,23 @@
              tfoot th thead time title tr track u ul use var video wbr circle clipPath ellipse g line mask path pattern
              polyline rect svg text defs linearGradient polygon radialGradient stop tspan})
 
+(defn gen-docstring
+  "Helper function for generating the docstrings for generated dom functions and
+  macros."
+  [tag client-side?]
+  (str "Returns a " (if client-side? "React" "server side")
+       " DOM element. Can be invoked in several ways\n\n"
 
+       "These two are made equivalent at compile time\n"
+       "(" tag " \"hello\")\n"
+       (str "(" tag " nil \"hello\")\n")
+       "\n"
+
+       "These two are made equivalent at compile time\n"
+       "(" tag " {:onClick f} \"hello\")\n"
+       "(" tag " #js {:onClick f} \"hello\")\n"
+       "\n"
+
+       "There is also a shorthand for CSS id and class names\n"
+       "(" tag " :#the-id.klass.other-klass \"hello\")\n"
+       "(" tag " :#the-id.klass.other-klass {:onClick f} \"hello\")"))

--- a/src/main/fulcro/client/dom_server.clj
+++ b/src/main/fulcro/client/dom_server.clj
@@ -408,7 +408,8 @@ void-tags
              :children  children})))
 
 (defn gen-tag-fn [tag]
-  `(defn ~tag [& ~'args]
+  `(defn ~tag ~(cdom/gen-docstring tag false)
+     [& ~'args]
      (let [conformed-args# (util/conform! ::dom-element-args ~'args)
            {attrs#    :attrs
             children# :children


### PR DESCRIPTION
https://github.com/fulcrologic/fulcro/issues/208

Appropriate tag names are used in the examples in the generated docstrings.

On the client side the docstring looks like this
```
fulcro.client.dom/span
 [& args]
Macro
  Returns a React DOM element. Can be invoked in several ways

These two are made equivalent at compile time
(span "hello")
(span nil "hello")

These two are made equivalent at compile time
(span {:onClick f} "hello")
(span #js {:onClick f} "hello")

There is also a shorthand for CSS id and class names
(span :#the-id.klass.other-klass "hello")
(span :#the-id.klass.other-klass {:onClick f} "hello")
```

And on the server side it looks like this
```
fulcro.client.dom-server/span
 [& args]
  Returns a server side DOM element. Can be invoked in several ways

These two are made equivalent at compile time
(span "hello")
(span nil "hello")

These two are made equivalent at compile time
(span {:onClick f} "hello")
(span #js {:onClick f} "hello")

There is also a shorthand for CSS id and class names
(span :#the-id.klass.other-klass "hello")
(span :#the-id.klass.other-klass {:onClick f} "hello")
```