### PR TITLE
Added remove-ident function with specs to primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ small and tractable.
 - (inc y) = Intrusive change that should not break anything, but should be heavily tested.
 - (inc z) = additions, bug fixes, etc.
 
+2.6.1
+------
+- Deprecated prim/integrate-ident and prim/integrate-ident! and moved logic to muations/integrate-ident*.
+- Added mutations/remove-ident* helper for removing idents from a list of idents in app state.
+- Added form-state/delete-form-state* for cleaning up data created by form-state.
+
 2.6.0
 -----
 - Updated so that using React 16.4 includes all lifecycle methods (UNSAFE, etc.), EXCEPT getDerivedStateFromProps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ small and tractable.
 - Added mutations/remove-ident* helper for removing idents from a list of idents in app state.
 - Added form-state/delete-form-state* for cleaning up data created by form-state.
 - Added sente-options argument to client side websockets, to mirror server side.
+- Sente channel socket type by default is now :auto, so it will fall back to ajax long polling if ws is not available.
 
 2.6.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ small and tractable.
 - Deprecated prim/integrate-ident and prim/integrate-ident! and moved logic to muations/integrate-ident*.
 - Added mutations/remove-ident* helper for removing idents from a list of idents in app state.
 - Added form-state/delete-form-state* for cleaning up data created by form-state.
+- Added sente-options argument to client side websockets, to mirror server side.
 
 2.6.0
 -----

--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -4737,12 +4737,11 @@ In our example, we'll assume the delete is global (removes the item from the lis
   "Mutation: Delete an item from a list"
   [{:keys [id]}]
   (action [{:keys [state]}]
-    (letfn [(filter-item [list] (filterv #(not= (second %) id) list))]
-      (swap! state
-        (fn [s]
-          (-> s
-            (update :items dissoc id) ; remove the item from the db (optional)
-            (m/remove-ident* [:lists 1 :list/items] [:items id]))))))) ; remove the item from the list of idents
+    (swap! state
+      (fn [s]
+        (-> s
+          (update :items dissoc id) ; remove the item from the db (optional)
+          (m/remove-ident* [:lists 1 :list/items] [:items id])))))) ; remove the item from the list of idents
 ```
 
 The source of the components for this demo are below. Make note of the use of `computed`.

--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -4742,7 +4742,7 @@ In our example, we'll assume the delete is global (removes the item from the lis
         (fn [s]
           (-> s
             (update :items dissoc id) ; remove the item from the db (optional)
-            (update-in [:lists 1 :list/items] filter-item))))))) ; remove the item from the list of idents
+            (m/remove-ident* [:lists 1 :list/items] [:items id]))))))) ; remove the item from the list of idents
 ```
 
 The source of the components for this demo are below. Make note of the use of `computed`.

--- a/src/book/book/demos/parent_child_ownership_relations.cljs
+++ b/src/book/book/demos/parent_child_ownership_relations.cljs
@@ -23,7 +23,7 @@
         (fn [s]
           (-> s
             (update :items dissoc id)
-            (update-in [:lists 1 :list/items] filter-item)))))))
+            (m/remove-ident* [:lists 1 :list/items] [:items id])))))))
 
 (defsc Item [this
              {:keys [item/id item/label] :as props}

--- a/src/book/book/demos/parent_child_ownership_relations.cljs
+++ b/src/book/book/demos/parent_child_ownership_relations.cljs
@@ -18,12 +18,11 @@
   "Mutation: Delete an item from a list"
   [{:keys [id]}]
   (action [{:keys [state]}]
-    (letfn [(filter-item [list] (filterv #(not= (second %) id) list))]
-      (swap! state
-        (fn [s]
-          (-> s
-            (update :items dissoc id)
-            (m/remove-ident* [:lists 1 :list/items] [:items id])))))))
+    (swap! state
+      (fn [s]
+        (-> s
+          (update :items dissoc id)
+          (m/remove-ident* [:lists 1 :list/items] [:items id]))))))
 
 (defsc Item [this
              {:keys [item/id item/label] :as props}

--- a/src/book/book/forms/forms_demo_3.cljs
+++ b/src/book/book/forms/forms_demo_3.cljs
@@ -40,8 +40,10 @@
     (let [new-phone    (f/build-form ValidatedPhoneForm {:db/id id :phone/type :home :phone/number ""})
           person-ident [:people/by-id person]
           phone-ident  (prim/ident ValidatedPhoneForm new-phone)]
-      (swap! state assoc-in phone-ident new-phone)
-      (prim/integrate-ident! state phone-ident :append (conj person-ident :person/phone-numbers)))))
+      (swap! state (fn [s]
+                     (-> s
+                         (assoc-in phone-ident new-phone)
+                         (m/integrate-ident* phone-ident :append (conj person-ident :person/phone-numbers))))))))
 
 (defsc ValidatedPhoneForm [this form]
   {:initial-state (fn [params] (f/build-form this (or params {})))

--- a/src/main/fulcro/client/mutations.cljc
+++ b/src/main/fulcro/client/mutations.cljc
@@ -2,7 +2,7 @@
   #?(:cljs (:require-macros fulcro.client.mutations))
   (:require
     [clojure.spec.alpha :as s]
-    [fulcro.util :refer [conform! join-key join-value join?]]
+    [fulcro.util :as util :refer [conform! join-key join-value join?]]
     [fulcro.logging :as log]
     [fulcro.client.primitives :as prim]
     #?(:cljs [cljs.loader :as loader])
@@ -307,3 +307,19 @@
   (let [new-list (fn [old-list]
                    (vec (filter #(not= ident %) old-list)))]
     (update-in state-map path-to-idents new-list)))
+
+(defn integrate-ident*
+  "Integrate an ident into any number of places in the app state. This function is safe to use within mutation
+  implementations as a general helper function.
+
+  The named parameters can be specified any number of times. They are:
+
+  - append:  A vector (path) to a list in your app state where this new object's ident should be appended. Will not append
+  the ident if that ident is already in the list.
+  - prepend: A vector (path) to a list in your app state where this new object's ident should be prepended. Will not append
+  the ident if that ident is already in the list.
+  - replace: A vector (path) to a specific location in app-state where this object's ident should be placed. Can target a to-one or to-many.
+   If the target is a vector element then that element must already exist in the vector."
+  [state ident & named-parameters]
+  {:pre [(map? state)]}
+  (apply util/__integrate-ident-impl__ state ident named-parameters))

--- a/src/main/fulcro/client/mutations.cljc
+++ b/src/main/fulcro/client/mutations.cljc
@@ -298,3 +298,12 @@
   (set (keep
          (fn [m] (some-> m seq first meta :fulcro.client.network/abort-id))
          tx)))
+
+(defn remove-ident*
+  "Removes an ident, if it exists, from a list of idents in app state. This
+  function is safe to use within mutations."
+  [state-map ident path-to-idents]
+  {:pre [(map? state-map)]}
+  (let [new-list (fn [old-list]
+                   (vec (filter #(not= ident %) old-list)))]
+    (update-in state-map path-to-idents new-list)))

--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -3179,15 +3179,6 @@
                   (throw (ex-info "Unknown post-op to merge-state!: " {:command command :arg data-path})))))
       state actions)))
 
-(defn remove-ident
-  "Removes an ident, if it exists, from a list of idents in app state. This
-  function is safe to use within mutations."
-  [state-map ident path-to-idents]
-  {:pre [(map? state-map)]}
-  (let [new-list (fn [old-list]
-                   (vec (filter #(not= ident %) old-list)))]
-    (update-in state-map path-to-idents new-list)))
-
 (defn component-merge-query
   "Calculates the query that can be used to pull (or merge) a component with an ident
   to/from a normalized app database. Requires a tree of data that represents the instance of
@@ -3236,14 +3227,6 @@
   (assert (is-atom? state)
     "The state has to be an atom. Use 'integrate-ident' instead.")
   (apply swap! state integrate-ident ident named-parameters))
-
-(defn remove-ident!
-  "Removes an ident, if it exists, from a list of idents in app state. This
-  function is safe to use within mutations."
-  [state ident path-to-idents]
-  (assert (is-atom? state)
-          "The state has to be an atom. Use 'remove-ident' instead.")
-  (swap! state remove-ident ident path-to-idents))
 
 (defn merge-component
   "Given a state map of the application database, a component, and a tree of component-data: normalizes

--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -3141,8 +3141,8 @@
   "DEPRECATED: Use fulcro.client.mutations/integrate-ident* in your mutations instead."
   [state ident & named-parameters]
   {:pre [(map? state)]}
-  (log/warn "This function has been been deprecated and will be removed in the future."
-            "Use fulcro.client.mutations/integrate-ident* in your mutations instead.")
+  (log/warn "integrate-ident is deprecated and will be removed in the future."
+            "Please use fulcro.client.mutations/integrate-ident* in your mutations instead.")
   (apply util/__integrate-ident-impl__ state ident named-parameters))
 
 (defn component-merge-query
@@ -3179,8 +3179,8 @@
 (defn integrate-ident!
   "DEPRECATED: Use fulcro.client.mutations/integrate-ident* in your mutations instead."
   [state ident & named-parameters]
-  (log/warn "This function has been been deprecated and will be removed in the future."
-            "Use fulcro.client.mutations/integrate-ident* in your mutations instead.")
+  (log/warn "integrate-ident! is deprecated and will be removed in the future."
+            "Please use fulcro.client.mutations/integrate-ident* in your mutations instead.")
   (assert (is-atom? state)
     "The state has to be an atom. Use 'integrate-ident' instead.")
   (apply swap! state util/__integrate-ident-impl__ ident named-parameters))

--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -3179,6 +3179,15 @@
                   (throw (ex-info "Unknown post-op to merge-state!: " {:command command :arg data-path})))))
       state actions)))
 
+(defn remove-ident
+  "Removes an ident, if it exists, from a list of idents in app state. This
+  function is safe to use within mutations."
+  [state-map ident path-to-idents]
+  {:pre [(map? state-map)]}
+  (let [new-list (fn [old-list]
+                   (vec (filter #(not= ident %) old-list)))]
+    (update-in state-map path-to-idents new-list)))
+
 (defn component-merge-query
   "Calculates the query that can be used to pull (or merge) a component with an ident
   to/from a normalized app database. Requires a tree of data that represents the instance of
@@ -3227,6 +3236,14 @@
   (assert (is-atom? state)
     "The state has to be an atom. Use 'integrate-ident' instead.")
   (apply swap! state integrate-ident ident named-parameters))
+
+(defn remove-ident!
+  "Removes an ident, if it exists, from a list of idents in app state. This
+  function is safe to use within mutations."
+  [state ident path-to-idents]
+  (assert (is-atom? state)
+          "The state has to be an atom. Use 'remove-ident' instead.")
+  (swap! state remove-ident ident path-to-idents))
 
 (defn merge-component
   "Given a state map of the application database, a component, and a tree of component-data: normalizes

--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -3243,7 +3243,9 @@
           {:keys [merge-data merge-query]} (preprocess-merge state component object-data)]
       (merge! reconciler merge-data merge-query)
       (swap! state dissoc :fulcro/merge)
-      (apply integrate-ident! state ident named-parameters)
+      ;; Use utils until we make smaller namespaces, requiring mutations would
+      ;; cause circular dependency.
+      (apply util/__integrate-ident-impl__ state ident named-parameters)
       (p/queue! reconciler (conj data-path-keys ident))
       @state)))
 

--- a/src/main/fulcro/client/primitives.cljc
+++ b/src/main/fulcro/client/primitives.cljc
@@ -3138,46 +3138,12 @@
     `(do (defsc ~t ~@args) ~t)))
 
 (defn integrate-ident
-  "Integrate an ident into any number of places in the app state. This function is safe to use within mutation
-  implementations as a general helper function.
-
-  The named parameters can be specified any number of times. They are:
-
-  - append:  A vector (path) to a list in your app state where this new object's ident should be appended. Will not append
-  the ident if that ident is already in the list.
-  - prepend: A vector (path) to a list in your app state where this new object's ident should be prepended. Will not append
-  the ident if that ident is already in the list.
-  - replace: A vector (path) to a specific location in app-state where this object's ident should be placed. Can target a to-one or to-many.
-   If the target is a vector element then that element must already exist in the vector."
+  "DEPRECATED: Use fulcro.client.mutations/integrate-ident* in your mutations instead."
   [state ident & named-parameters]
   {:pre [(map? state)]}
-  (let [actions (partition 2 named-parameters)]
-    (reduce (fn [state [command data-path]]
-              (let [already-has-ident-at-path? (fn [data-path] (some #(= % ident) (get-in state data-path)))]
-                (case command
-                  :prepend (if (already-has-ident-at-path? data-path)
-                             state
-                             (do
-                               (assert (vector? (get-in state data-path)) (str "Path " data-path " for prepend must target an app-state vector."))
-                               (update-in state data-path #(into [ident] %))))
-                  :append (if (already-has-ident-at-path? data-path)
-                            state
-                            (do
-                              (assert (vector? (get-in state data-path)) (str "Path " data-path " for append must target an app-state vector."))
-                              (update-in state data-path conj ident)))
-                  :replace (let [path-to-vector (butlast data-path)
-                                 to-many?       (and (seq path-to-vector) (vector? (get-in state path-to-vector)))
-                                 index          (last data-path)
-                                 vector         (get-in state path-to-vector)]
-                             (assert (vector? data-path) (str "Replacement path must be a vector. You passed: " data-path))
-                             (when to-many?
-                               (do
-                                 (assert (vector? vector) "Path for replacement must be a vector")
-                                 (assert (number? index) "Path for replacement must end in a vector index")
-                                 (assert (contains? vector index) (str "Target vector for replacement does not have an item at index " index))))
-                             (assoc-in state data-path ident))
-                  (throw (ex-info "Unknown post-op to merge-state!: " {:command command :arg data-path})))))
-      state actions)))
+  (log/warn "This function has been been deprecated and will be removed in the future."
+            "Use fulcro.client.mutations/integrate-ident* in your mutations instead.")
+  (apply util/__integrate-ident-impl__ state ident named-parameters))
 
 (defn component-merge-query
   "Calculates the query that can be used to pull (or merge) a component with an ident
@@ -3211,22 +3177,13 @@
                 :clj  clojure.lang.Atom) x))
 
 (defn integrate-ident!
-  "Integrate an ident into any number of places in the app state. This function is safe to use within mutation
-  implementations as a general helper function.
-
-  The named parameters can be specified any number of times. They are:
-
-  - append:  A vector (path) to a list in your app state where this new object's ident should be appended. Will not append
-  the ident if that ident is already in the list.
-  - prepend: A vector (path) to a list in your app state where this new object's ident should be prepended. Will not append
-  the ident if that ident is already in the list.
-  - replace: A vector (path) to a specific location in app-state where this object's ident should be placed. Can target a to-one or to-many.
-   If the target is a vector element then that element must already exist in the vector.
-  "
+  "DEPRECATED: Use fulcro.client.mutations/integrate-ident* in your mutations instead."
   [state ident & named-parameters]
+  (log/warn "This function has been been deprecated and will be removed in the future."
+            "Use fulcro.client.mutations/integrate-ident* in your mutations instead.")
   (assert (is-atom? state)
     "The state has to be an atom. Use 'integrate-ident' instead.")
-  (apply swap! state integrate-ident ident named-parameters))
+  (apply swap! state util/__integrate-ident-impl__ ident named-parameters))
 
 (defn merge-component
   "Given a state map of the application database, a component, and a tree of component-data: normalizes

--- a/src/main/fulcro/ui/file_upload.cljc
+++ b/src/main/fulcro/ui/file_upload.cljc
@@ -12,7 +12,7 @@
     [fulcro.client :as fc]
     [fulcro.ui.forms :as f]
     [fulcro.ui.icons :as icons]
-    [fulcro.client.mutations :refer [defmutation]]
+    [fulcro.client.mutations :as m :refer [defmutation]]
     [fulcro.client.network :as net]
     [fulcro.logging :as log]
     #?(:clj
@@ -311,11 +311,10 @@
      `file-id` is the ID of the file to cancel."
      [{:keys [upload-id file-id]}]
      (action [{:keys [state]}]
-       (let [remove-ident (fn [i v] (into [] (filter #(not= i %) v)))
-             files-path   (conj (file-upload-ident upload-id) :file-upload/files)]
+       (let [files-path   (conj (file-upload-ident upload-id) :file-upload/files)]
          (swap! state (fn [st] (-> st
                                  (update :file-upload-file/by-id dissoc file-id)
-                                 (update-in files-path (partial remove-ident (file-ident file-id))))))))
+                                 (m/remove-ident* (file-ident file-id) files-path))))))
      (file-upload [env] true)))
 
 #?(:cljs

--- a/src/main/fulcro/ui/form_state.cljc
+++ b/src/main/fulcro/ui/form_state.cljc
@@ -561,7 +561,9 @@
               (apply dissoc s ks)))))
 
 (s/fdef delete-form-state*
-        :args (s/cat :state-map map? :entity-idents (s/* util/ident?))
+        :args (s/cat :state-map map?
+                     :entity-ident-or-idents (s/or :entity-ident util/ident?
+                                                   :entity-idents (s/coll-of util/ident?)))
         :ret map?)
 
 (defn pristine->entity*

--- a/src/main/fulcro/ui/form_state.cljc
+++ b/src/main/fulcro/ui/form_state.cljc
@@ -546,6 +546,20 @@
   :args (s/cat :state map? :entity-ident util/ident? :field (s/? keyword?))
   :ret map?)
 
+(defn delete-form-state*
+  "Removes copies of entities used by form-state logic."
+  [state-map & entity-idents]
+  (let [ks (mapv (fn [[t r]]
+                   {:table t :row r})
+                 entity-idents)]
+    (update state-map ::forms-by-ident
+            (fn [s]
+              (apply dissoc s ks)))))
+
+(s/fdef delete-form-state*
+        :args (s/cat :state-map map? :entity-idents (s/* util/ident?))
+        :ret map?)
+
 (defn pristine->entity*
   "Copy the pristine state over top of the originating entity of the given form. Meant to be used inside of a
   mutation. Recursively follows subforms in app state. Returns the new app state map.

--- a/src/main/fulcro/ui/form_state.cljc
+++ b/src/main/fulcro/ui/form_state.cljc
@@ -548,8 +548,12 @@
 
 (defn delete-form-state*
   "Removes copies of entities used by form-state logic."
-  [state-map & entity-idents]
-  (let [ks (mapv (fn [[t r]]
+  [state-map entity-ident-or-idents]
+  (let [entity-idents (if (util/ident? entity-ident-or-idents)
+                       [entity-ident-or-idents]
+                       entity-ident-or-idents)
+
+        ks (mapv (fn [[t r]]
                    {:table t :row r})
                  entity-idents)]
     (update state-map ::forms-by-ident

--- a/src/main/fulcro/websockets.cljs
+++ b/src/main/fulcro/websockets.cljs
@@ -26,7 +26,7 @@
                                           websockets-uri ; path on server
                                           (merge {:packer         (tp/make-packer transit-handlers)
                                                   :host           host
-                                                  :type           :ws ; e/o #{:auto :ajax :ws}
+                                                  :type           :auto ; e/o #{:auto :ajax :ws}
                                                   :backoff-ms-fn  (fn [attempt] (min (* attempt 1000) 4000))
                                                   :params         req-params
                                                   :wrap-recv-evs? false}

--- a/src/test/fulcro/client/mutations_spec.cljs
+++ b/src/test/fulcro/client/mutations_spec.cljs
@@ -293,3 +293,24 @@
     (assertions
       "extracts the set of distinct abort IDs for the mutations in a transaction"
       (m/abort-ids tx) => #{:abort-id :other-abort-id})))
+
+(specification "remove-ident" :focused
+  (let [state {:a {:b {:c [[:item/by-id 1]
+                           [:item/by-id 2]
+                           [:item/by-id 3]]}}}
+        path  [:a :b :c]]
+    (assertions
+      "Can remove a target ident"
+      (-> state
+          (m/remove-ident* [:item/by-id 1] path)
+          (get-in path))
+      => [[:item/by-id 2]
+          [:item/by-id 3]]
+
+      "Removing a missing ident results in a no-op"
+      (-> state
+          (m/remove-ident* [:item/by-id 100] path)
+          (get-in path))
+      => [[:item/by-id 1]
+          [:item/by-id 2]
+          [:item/by-id 3]])))

--- a/src/test/fulcro/client/primitives_spec.cljc
+++ b/src/test/fulcro/client/primitives_spec.cljc
@@ -1753,6 +1753,27 @@
         (get-in [:many :path]))
       => [[:table 99] [:table 3] [:table 77]])))
 
+(specification "remove-ident"
+  (let [state {:a {:b {:c [[:item/by-id 1]
+                           [:item/by-id 2]
+                           [:item/by-id 3]]}}}
+        path  [:a :b :c]]
+    (assertions
+      "Can remove a target ident"
+      (-> state
+          (prim/remove-ident [:item/by-id 1] path)
+          (get-in path))
+      => [[:item/by-id 2]
+          [:item/by-id 3]]
+
+      "Removing a missing ident results in a no-op"
+      (-> state
+          (prim/remove-ident [:item/by-id 100] path)
+          (get-in path))
+      => [[:item/by-id 1]
+          [:item/by-id 2]
+          [:item/by-id 3]])))
+
 (defui ^:once MergeX
   static prim/InitialAppState
   (initial-state [this params] {:type :x :n :x})

--- a/src/test/fulcro/client/primitives_spec.cljc
+++ b/src/test/fulcro/client/primitives_spec.cljc
@@ -1753,27 +1753,6 @@
         (get-in [:many :path]))
       => [[:table 99] [:table 3] [:table 77]])))
 
-(specification "remove-ident"
-  (let [state {:a {:b {:c [[:item/by-id 1]
-                           [:item/by-id 2]
-                           [:item/by-id 3]]}}}
-        path  [:a :b :c]]
-    (assertions
-      "Can remove a target ident"
-      (-> state
-          (prim/remove-ident [:item/by-id 1] path)
-          (get-in path))
-      => [[:item/by-id 2]
-          [:item/by-id 3]]
-
-      "Removing a missing ident results in a no-op"
-      (-> state
-          (prim/remove-ident [:item/by-id 100] path)
-          (get-in path))
-      => [[:item/by-id 1]
-          [:item/by-id 2]
-          [:item/by-id 3]])))
-
 (defui ^:once MergeX
   static prim/InitialAppState
   (initial-state [this params] {:type :x :n :x})

--- a/src/test/fulcro/ui/form_state_spec.cljc
+++ b/src/test/fulcro/ui/form_state_spec.cljc
@@ -125,10 +125,16 @@
                                          :ui/n  22}}}
         configured-db (f/add-form-config* state-map Person [:person/by-id 1])]
     (assertions
-      "Removes form states of entity-idents"
+      "Removes form states of multiple entity-idents"
       (-> configured-db
-          (f/delete-form-state* [:person/by-id 1]
-                                [:phone/by-id 5])
+          (f/delete-form-state* [[:person/by-id 1]
+                                 [:phone/by-id 5]])
+          ::f/forms-by-ident)
+      => {}
+      "Removes form states of one entity-ident at a time"
+      (-> configured-db
+          (f/delete-form-state* [:person/by-id 1])
+          (f/delete-form-state* [:phone/by-id 5])
           ::f/forms-by-ident)
       => {})))
 

--- a/src/test/fulcro/ui/form_state_spec.cljc
+++ b/src/test/fulcro/ui/form_state_spec.cljc
@@ -117,6 +117,21 @@
       (get-in configured-db [:person/by-id 1 :ui/checked?]) => true
       (get-in configured-db [:phone/by-id 5 :ui/n]) => 22)))
 
+(specification "delete-form-state*"
+  (let [state-map     {:person/by-id {1 {:db/id          1 ::person-name "Joe" :ui/checked? true
+                                         ::phone-numbers [[:phone/by-id 5]]}}
+                       :root-prop    99
+                       :phone/by-id  {5 {:db/id 5 ::phone-number "555-4444"
+                                         :ui/n  22}}}
+        configured-db (f/add-form-config* state-map Person [:person/by-id 1])]
+    (assertions
+      "Removes form states of entity-idents"
+      (-> configured-db
+          (f/delete-form-state* [:person/by-id 1]
+                                [:phone/by-id 5])
+          ::f/forms-by-ident)
+      => {})))
+
 (let [locale                                  {:db/id 22 ::country :US}
       locale                                  (f/add-form-config Locale locale)
       phone-numbers                           [{:db/id 2 ::phone-number "555-1212" ::locale locale} {:db/id 3 ::phone-number "555-1212"}]


### PR DESCRIPTION
@awkay you said

> 1. Helper functions for targeted state manipulation when you know what you want to remove. Not really GC, but helpful. These would be functions like remove-ident, delete-form-state, etc.
> 2. Semi-automated GC...e.g. (recursive-delete some-ident), which delete the table entry at ident, and ALSO follows idents starting at that entity, and removes all children. This requires something like a white-list/black-list of table names, or a set of "isComponent" Datomic-like indicators to prevent unintentional traversal.
> 3. Fully-automated GC. The function scans entire app state removing things that are not referenced. This one also needs "help" in that unions may not be currently pointing at data that needs to be kept.

At the moment I only needed (1), so that's all I did. If the need for (2) or (3) arrises, I'll submit another PR.

Also, after this is merged I can update the book examples to use it. 

https://github.com/fulcrologic/fulcro/issues/216