### PR TITLE
Loosen restrictions on load markers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -83,7 +83,7 @@
                                :output-to            "resources/public/js/cards.js"
                                :output-dir           "resources/public/js/cards"
                                :asset-path           "js/cards"
-                               :preloads             [devtools.preload]
+                               :preloads             [devtools.preload fulcro.inspect.preload]
                                ;:parallel-build       true
                                ;:verbose              true
                                ;:compiler-stats       true
@@ -141,7 +141,7 @@
                     :dependencies [[binaryage/devtools "0.9.10"]
                                    [com.rpl/specter "1.1.1"] ; used by book demos
                                    [devcards "0.2.4" :exclusions [org.clojure/clojure cljsjs/react cljsjs/react-dom]]
-                                   [fulcrologic/fulcro-inspect "2.2.0-beta8" :exclusions [fulcrologic/fulcro]]
+                                   [fulcrologic/fulcro-inspect "2.2.1" :exclusions [fulcrologic/fulcro]]
                                    [com.cemerick/piggieback "0.2.2"]
                                    [figwheel-sidecar "0.5.15"]
                                    [cljsjs/d3 "4.12.0-0"]

--- a/src/cards/fulcro/democards/load_cards.cljs
+++ b/src/cards/fulcro/democards/load_cards.cljs
@@ -161,3 +161,16 @@
                                       (df/load app ::x nil {:target [:T 1 :a]})
                                       (df/load app ::x nil {:target [:T 1 :b]})
                                       (df/load app ::x nil {:target [:T 1 :c]}))}})
+
+(defsc Item [_ _]
+  {:initial-state (fn [_] {:id "sample"})
+   :ident [:id :id]
+   :query [:id :name]}
+  (dom/div "Item"))
+
+(defcard-fulcro vector-marker
+  (make-root Item {})
+  {}
+  {:fulcro {:networking       (MockNetForEcho.)
+            :started-callback (fn [app]
+                                (df/load app [:id "sample"] Item {:marker [:id "sample"]}))}})

--- a/src/main/fulcro/client/data_fetch.cljc
+++ b/src/main/fulcro/client/data_fetch.cljc
@@ -58,7 +58,6 @@
                                                         :or   {remote     :remote marker true parallel false refresh [] without #{}
                                                                initialize false}}]
   {:pre [(or (nil? target) (vector? target))
-         (or (nil? marker) (bool? marker) (keyword? marker))
          (or (nil? post-mutation) (symbol? post-mutation))
          (or (nil? fallback) (symbol? fallback))
          (or (nil? post-mutation-params) (map? post-mutation-params))

--- a/src/main/fulcro/client/impl/data_fetch.cljc
+++ b/src/main/fulcro/client/impl/data_fetch.cljc
@@ -21,7 +21,7 @@
 (s/def ::post-mutation (optional symbol?))
 (s/def ::post-mutation-params (optional map?))
 (s/def ::refresh (optional vector?))
-(s/def ::marker (s/or :kw keyword? :bool boolean? :nothing nil?))
+(s/def ::marker (s/or :reference any? :bool boolean? :nothing (s/or :nil nil? :false false?)))
 (s/def ::parallel (optional boolean?))
 (s/def ::fallback (optional symbol?))
 (s/def ::original-env map?)
@@ -70,7 +70,7 @@
 
 (defn- place-load-marker [state-map marker]
   (let [marker-id      (data-marker marker)
-        legacy-marker? (-> marker-id keyword? not)]
+        legacy-marker? (true? marker-id)]
     (if legacy-marker?
       (update-in state-map (data-path marker)
         (fn [current-val]
@@ -463,7 +463,7 @@
   "Returns app-state without the load marker for the given item."
   [app-state item]
   (let [marker-id      (data-marker item)
-        legacy-marker? (-> marker-id keyword? not)]
+        legacy-marker? (true? marker-id)]
     (if legacy-marker?
       (let [path (data-path item)
             data (get-in app-state path)]


### PR DESCRIPTION
This PR makes changes to allow the use of other things than keywords as load markers. This facilitates creating composed markers by allowing anything to be a marker key (not just keywords).