### PR TITLE
Base64 the SSR initial state string to prevent encoding issues

### DIFF
--- a/src/main/fulcro/server_render.cljc
+++ b/src/main/fulcro/server_render.cljc
@@ -18,8 +18,8 @@
      ([initial-state opts] (initial-state->script-tag initial-state opts identity))
      ([initial-state opts string-transform]
       (let [state-string (-> (util/transit-clj->str initial-state opts)
-                             (clojure.string/replace #"'" "\\\\'")
-                             (string-transform))
+                             (string-transform)
+                             (util/base64-encode))
             assignment   (str "window.INITIAL_APP_STATE = '" state-string "'")]
         (str
          "<script type='text/javascript'>\n"
@@ -31,7 +31,7 @@
      "Obtain the value of the INITIAL_APP_STATE set from server-side rendering. Use initial-state->script-tag on the server to embed the state."
      ([] (get-SSR-initial-state {}))
      ([opts]
-      (when-let [state-string (.-INITIAL_APP_STATE js/window)]
+      (when-let [state-string (util/base64-decode (.-INITIAL_APP_STATE js/window))]
         (util/transit-str->clj state-string opts)))))
 
 (defn build-initial-state

--- a/src/test/fulcro/server_render_spec.cljc
+++ b/src/test/fulcro/server_render_spec.cljc
@@ -46,55 +46,37 @@
    (specification "SSR script tag generation"
      (assertions
        "puts an assignment on the document window"
-       (ssr/initial-state->script-tag []) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'W10='\n</script>\n")))
-
-#?(:clj
-   (specification "SSR script tag generation w/ apos"
-                  (assertions
-                    "puts an assignment on the document window with some tricky content"
-                    (ssr/initial-state->script-tag {:some-field "some text's apostrophe"}) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'WyJeICIsIn46c29tZS1maWVsZCIsInNvbWUgdGV4dCdzIGFwb3N0cm9waGUiXQ=='\n</script>\n")))
-
-#?(:clj
-   (specification "SSR script tag generation w/ emoji"
-     (assertions
-       "puts an assignment on the document window with some emoji content"
-       (ssr/initial-state->script-tag {:emoji "\u26d1"}) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'WyJeICIsIn46ZW1vamkiLCLim5EiXQ=='\n</script>\n")))
-
-#?(:clj
-   (specification "SSR script tag generation w/ naughty strings"
-                  (assertions
-                    "puts an assignment on the document window with some nefarious content"
-                    (ssr/initial-state->script-tag {:naughty "\u0001\u0002\u0003\u0004\u0005"}) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'WyJeICIsIn46bmF1Z2h0eSIsIlx1MDAwMVx1MDAwMlx1MDAwM1x1MDAwNFx1MDAwNSJd'\n</script>\n")))
-
-#?(:cljs
+       (ssr/initial-state->script-tag []) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'W10='\n</script>\n"))
+   :cljs
    (specification "SSR initial-state extraction"
      (set! (.-INITIAL_APP_STATE js/window) "W10=")
      (assertions
        "Can pull the initial state from the document's window"
        (ssr/get-SSR-initial-state) => [])))
 
-#?(:cljs
-   (specification "SSR initial-state extraction w/ apos"
-     (set! (.-INITIAL_APP_STATE js/window) "WyJeICIsIn46c29tZS1maWVsZCIsInNvbWUgdGV4dCdzIGFwb3N0cm9waGUiXQ==")
+#?(:clj
+   (specification "SSR script tag generation w/ emoji"
+     (assertions
+       "puts an assignment on the document window with some emoji content"
+       (ssr/initial-state->script-tag {:emoji "\u26d1"}) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'WyJeICIsIn46ZW1vamkiLCLim5EiXQ=='\n</script>\n"))
+   :cljs
+   (specification "SSR initial-state extraction w/ emoji"
+     (set! (.-INITIAL_APP_STATE js/window) "WyJeICIsIn46ZW1vamkiLCLim5EiXQ==")
      (assertions
        "Can pull the initial state from the document's window"
-       (ssr/get-SSR-initial-state) => {:some-field "some text's apostrophe"})))
+       (ssr/get-SSR-initial-state) => {:emoji "\u26d1"})))
 
-#?(:cljs
-   (specification "SSR initial-state extraction w/ emoji"
-                  (set! (.-INITIAL_APP_STATE js/window) "WyJeICIsIn46ZW1vamkiLCLim5EiXQ==")
-                  (assertions
-                    "Can pull the initial state from the document's window"
-                    (ssr/get-SSR-initial-state) => {:emoji "\u26d1"})))
-
-#?(:cljs
+#?(:clj
+   (specification "SSR script tag generation w/ naughty strings"
+     (assertions
+       "puts an assignment on the document window with some nefarious content"
+       (ssr/initial-state->script-tag {:naughty "\u0001\u0002\u0003\u0004\u0005"}) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'WyJeICIsIn46bmF1Z2h0eSIsIlx1MDAwMVx1MDAwMlx1MDAwM1x1MDAwNFx1MDAwNSJd'\n</script>\n"))
+   :cljs
    (specification "SSR initial-state extraction w/ naughty string"
-                  (set! (.-INITIAL_APP_STATE js/window) "WyJeICIsIn46bmF1Z2h0eSIsIlx1MDAwMVx1MDAwMlx1MDAwM1x1MDAwNFx1MDAwNSJd")
-                  (assertions
-                    "Can pull the initial state from the document's window"
-                    (ssr/get-SSR-initial-state) => {:naughty "\u0001\u0002\u0003\u0004\u0005"})))
-
-
+     (set! (.-INITIAL_APP_STATE js/window) "WyJeICIsIn46bmF1Z2h0eSIsIlx1MDAwMVx1MDAwMlx1MDAwM1x1MDAwNFx1MDAwNSJd")
+     (assertions
+       "Can pull the initial state from the document's window"
+       (ssr/get-SSR-initial-state) => {:naughty "\u0001\u0002\u0003\u0004\u0005"})))
 
 (def table-1 {:type :table :id 1 :rows [1 2 3]})
 (defui Table

--- a/src/test/fulcro/server_render_spec.cljc
+++ b/src/test/fulcro/server_render_spec.cljc
@@ -46,21 +46,55 @@
    (specification "SSR script tag generation"
      (assertions
        "puts an assignment on the document window"
-       (ssr/initial-state->script-tag []) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = '[]'\n</script>\n")))
+       (ssr/initial-state->script-tag []) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'W10='\n</script>\n")))
 
 #?(:clj
    (specification "SSR script tag generation w/ apos"
+                  (assertions
+                    "puts an assignment on the document window with some tricky content"
+                    (ssr/initial-state->script-tag {:some-field "some text's apostrophe"}) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'WyJeICIsIn46c29tZS1maWVsZCIsInNvbWUgdGV4dCdzIGFwb3N0cm9waGUiXQ=='\n</script>\n")))
+
+#?(:clj
+   (specification "SSR script tag generation w/ emoji"
      (assertions
-       "puts an assignment on the document window with some tricky content"
-       (ssr/initial-state->script-tag {:some-field "some text's apostrophe"}) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = '[\"^ \",\"~:some-field\",\"some text\\'s apostrophe\"]'\n</script>\n")))
+       "puts an assignment on the document window with some emoji content"
+       (ssr/initial-state->script-tag {:emoji "\u26d1"}) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'WyJeICIsIn46ZW1vamkiLCLim5EiXQ=='\n</script>\n")))
+
+#?(:clj
+   (specification "SSR script tag generation w/ naughty strings"
+                  (assertions
+                    "puts an assignment on the document window with some nefarious content"
+                    (ssr/initial-state->script-tag {:naughty "\u0001\u0002\u0003\u0004\u0005"}) => "<script type='text/javascript'>\nwindow.INITIAL_APP_STATE = 'WyJeICIsIn46bmF1Z2h0eSIsIlx1MDAwMVx1MDAwMlx1MDAwM1x1MDAwNFx1MDAwNSJd'\n</script>\n")))
 
 #?(:cljs
    (specification "SSR initial-state extraction"
-     (let [state (util/transit-clj->str [])]
-       (set! (.-INITIAL_APP_STATE js/window) state)
-       (assertions
-         "Can pull the initial state from the document's window"
-         (ssr/get-SSR-initial-state) => []))))
+     (set! (.-INITIAL_APP_STATE js/window) "W10=")
+     (assertions
+       "Can pull the initial state from the document's window"
+       (ssr/get-SSR-initial-state) => [])))
+
+#?(:cljs
+   (specification "SSR initial-state extraction w/ apos"
+     (set! (.-INITIAL_APP_STATE js/window) "WyJeICIsIn46c29tZS1maWVsZCIsInNvbWUgdGV4dCdzIGFwb3N0cm9waGUiXQ==")
+     (assertions
+       "Can pull the initial state from the document's window"
+       (ssr/get-SSR-initial-state) => {:some-field "some text's apostrophe"})))
+
+#?(:cljs
+   (specification "SSR initial-state extraction w/ emoji"
+                  (set! (.-INITIAL_APP_STATE js/window) "WyJeICIsIn46ZW1vamkiLCLim5EiXQ==")
+                  (assertions
+                    "Can pull the initial state from the document's window"
+                    (ssr/get-SSR-initial-state) => {:emoji "\u26d1"})))
+
+#?(:cljs
+   (specification "SSR initial-state extraction w/ naughty string"
+                  (set! (.-INITIAL_APP_STATE js/window) "WyJeICIsIn46bmF1Z2h0eSIsIlx1MDAwMVx1MDAwMlx1MDAwM1x1MDAwNFx1MDAwNSJd")
+                  (assertions
+                    "Can pull the initial state from the document's window"
+                    (ssr/get-SSR-initial-state) => {:naughty "\u0001\u0002\u0003\u0004\u0005"})))
+
+
 
 (def table-1 {:type :table :id 1 :rows [1 2 3]})
 (defui Table


### PR DESCRIPTION
The SSR initial state only escaped a apostrophe, but was otherwise suspect to encoding issues. Consider for example the JS string:

```JavaScript
window.INITIAL_APP_STATE = '"\u0001\u0002\u0003\u0004\u0006"';
```

This could both be generated by `initial-state->script-tag` and causes errors on the frontend. The problem here is that first the JS engine converts the unicode escape sequences to actual characters (depicted by `*`):

```JavaScript
window.INITIAL_APP_STATE ='"*****"';
```

Which is then (via transit) fed into a JSON parser. However the JSON standard prohibits any unicode control character (codepoint below 32) from appearing in a JSON string.

The solution here would be to doubly escape the slashes like so:

```JavaScript
window.INITIAL_APP_STATE = '"\\u0001\\u0002\\u0003\\u0004\\u0006"'
```

Which would cause the JS engine to strip the first slash, and the JSON parsing to replace the unicode escape sequence with its actual character. This however turns out to be pretty complex with all sorts of possible input.

Now, this patch encodes/decodes the transit generated to base64 to prevent these issues from happening at all. The JS engine assigns no special meaning to any of the b64 characters and
therefore leaves our string alone. The only interpreting of escape sequences now happens in the JSON decoder.

Finally, the decode/encode to b64 is also a bit of a can of worms as the default js functions are only defined to work for LATIN-1 characters. Therefore the utility functions in this patch use google's closure libraries to treat the base64 strings as UTF-8 byte arrays.

We have successfully tested a patch like this one with the [big list of naughty strings](https://github.com/minimaxir/big-list-of-naughty-strings) and I have added some exceptional cases to the tests.