### PR TITLE
Filter deprecated translations

### DIFF
--- a/src/main/fulcro/gettext.clj
+++ b/src/main/fulcro/gettext.clj
@@ -24,7 +24,7 @@
 
 (defn get-blocks
   [resource]
-  (filter (comp not is-header?) (map strip-comments (str/split (slurp resource) #"\n\n"))))
+  (filter (comp not is-header?) (remove str/blank? (map strip-comments (str/split (slurp resource) #"\n\n")))))
 
 (defn stripquotes [s]
   (-> s

--- a/src/test/fulcro/gettext_spec.clj
+++ b/src/test/fulcro/gettext_spec.clj
@@ -26,7 +26,7 @@
 (specification "block->translation"
   (let [translations (map gettext/block->translation (gettext/get-blocks (io/resource "resources/test.po")))]
     (assertions
-      translations => [{:msgid "Hello" :msgstr "" }
+      translations => [{:msgid "Hello" :msgstr ""}
                        {:msgctxt "Abbreviation for Monday" :msgid "M" :msgstr ""}
                        {:msgid "{n,plural,=0 {none} =1 {one} other {#}}\\n\\n      and some\\n      \\\" embedded weirdness \\n"
                         :msgstr ""}])))

--- a/src/test/resources/test.po
+++ b/src/test/resources/test.po
@@ -34,3 +34,6 @@ msgid ""
 "      and some\n"
 "      \" embedded weirdness \n"
 msgstr ""
+
+#~ msgid "No longer translated"
+#~ msgstr ""


### PR DESCRIPTION
It appeared to us, that deprecating translations would cause warnings after i18n extraction and merger. On page load multiple lines of `Unexpected input --> <--` were dropped, originating here https://github.com/fulcrologic/fulcro/blob/33bae48ef2830137059d74066ef61396583821f9/src/main/fulcro/gettext.clj#L45.

This PR fixes these warnings by removing all superfluous lines that would be blank after comment stripping, so they are not considered at all when creating the translation map.