### PR TITLE
Fix dom/wrap-form-element bug #271

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,8 @@
                  [fulcrologic/fulcro-spec "2.1.2" :scope "test" :exclusions [fulcrologic/fulcro]]
                  [lein-doo "0.1.10" :scope "test"]
                  [com.ibm.icu/icu4j "62.1" :scope "test"]
-                 [org.clojure/test.check "0.10.0-alpha3" :scope "test"]]
+                 [org.clojure/test.check "0.10.0-alpha3" :scope "test"]
+                 [cljsjs/enzyme "3.8.0" :scope "test"]]
 
   :source-paths ["src/main"]
   :jar-exclusions [#"public/.*" #"private/.*"]

--- a/src/main/fulcro/client/dom.cljs
+++ b/src/main/fulcro/client/dom.cljs
@@ -113,7 +113,8 @@
 (defonce form-elements? #{"input" "select" "option" "textarea"})
 
 (defn is-form-element? [element]
-  (form-elements? (str/lower-case (.-tagName element))))
+  (let [tag (.-tagName element)]
+    (and tag (form-elements? (str/lower-case tag)))))
 
 (defn wrap-form-element [element]
   (let [ctor (fn [props]

--- a/src/main/fulcro/client/dom.cljs
+++ b/src/main/fulcro/client/dom.cljs
@@ -9,6 +9,7 @@
     [cljsjs.react]
     [cljsjs.react.dom]
     [goog.object :as gobj]
+    [goog.dom :as gdom]
     [fulcro.client.dom-common :as cdom]))
 
 (declare a abbr address altGlyph altGlyphDef altGlyphItem animate animateColor animateMotion animateTransform area
@@ -109,6 +110,11 @@
       (gobj/set next-state "ref" inputRef))
     (.setState component next-state)))
 
+(defonce form-elements? #{"input" "select" "option" "textarea"})
+
+(defn is-form-element? [element]
+  (form-elements? (str/lower-case (.-tagName element))))
+
 (defn wrap-form-element [element]
   (let [ctor (fn [props]
                (this-as this
@@ -132,7 +138,11 @@
 
       (componentWillReceiveProps [this new-props]
         (let [state-value   (gobj/getValueByKeys this "state" "value")
-              element-value (gobj/get (js/ReactDOM.findDOMNode this) "value")]
+              this-node     (js/ReactDOM.findDOMNode this)
+              value-node    (if (is-form-element? this-node) 
+                              this-node
+                              (gdom/findNode this-node #(is-form-element? %)))
+              element-value (gobj/get value-node  "value")]
           (if (not= state-value element-value)
             (update-state this new-props element-value)
             (update-state this new-props (gobj/get new-props "value")))))
@@ -176,7 +186,6 @@
       "select" (apply wrapped-select props children)
       "option" (apply wrapped-option props children))))
 
-(defonce form-elements? #{"input" "select" "option" "textarea"})
 
 ;; fallback if the macro didn't do this
 (defn macro-create-element

--- a/src/test/fulcro/client/data_fetch_spec.cljc
+++ b/src/test/fulcro/client/data_fetch_spec.cljc
@@ -787,7 +787,7 @@
 (defmethod m/mutate `unhappy-mutation [env _ params]
   (throw (ex-info "Boo!" {})))
 
-(specification "mutation-remotes" :focused
+(specification "mutation-remotes"
   (assertions
     "Only returns remotes, not custom actions"
     (df/mutation-remotes {} (prim/query->ast1 `[(f {})]) #{:remote}) => #{:remote}

--- a/src/test/fulcro/client/impl/data_targeting_spec.cljc
+++ b/src/test/fulcro/client/impl/data_targeting_spec.cljc
@@ -7,7 +7,7 @@
 
 (defsc A [_ _])
 
-(specification "Special targeting" :focused
+(specification "Special targeting"
   (assertions
     "Reports false for non-special targets"
     (targeting/special-target? [:class]) => false

--- a/src/test/fulcro/client/primitives_spec.cljc
+++ b/src/test/fulcro/client/primitives_spec.cljc
@@ -308,7 +308,7 @@
       "Preserves the query when parameters are present"
       (prim/get-query ui-rootp state-parameterized) => parameterized-query)))
 
-(specification "Setting a query" :focused
+(specification "Setting a query"
   (let [query               (prim/get-query ui-root {})
         state               (prim/normalize-query {} query)
         state-modified      (prim/set-query* state ui-b {:query [:MODIFIED]})
@@ -345,7 +345,7 @@
   {:query [:id {:x (prim/get-query T2C1)}]
    :ident [:a/by-id :id]})
 
-(specification "Compount set-query" :focused
+(specification "Compound set-query"
   (let [state       {}
         new-state   (as-> state s
                       (prim/set-query* s T2C1 {:query [:id :address]})
@@ -1759,7 +1759,7 @@
       (assertions
         (get-in @state [:many :path]) => [[:table 99] [:table 3] [:table 77]]))))
 
-(specification "integrate-ident" :focused
+(specification "integrate-ident"
   (let [state {:a    {:path [[:table 2]]}
                :b    {:path [[:table 2]]}
                :d    [:table 6]


### PR DESCRIPTION
This PR addresses #271 by drilling down through any nested tags that may be present around the wrapped form element to establish its value. Tests are included.

Introduces a test dependency on [enzyme](https://airbnb.io/enzyme/).

Some hanging :focused markers are also removed.