### PR TITLE
Transform and pass response headers through client middleware

### DIFF
--- a/src/main/fulcro/client/network.cljc
+++ b/src/main/fulcro/client/network.cljc
@@ -40,6 +40,7 @@
              error)))
 #?(:cljs (defn xhrio-error-text [xhrio] (.getLastError xhrio)))
 #?(:cljs (defn xhrio-response-text [xhrio] (.getResponseText xhrio)))
+#?(:cljs (defn xhrio-response-headers [xhrio] (js->clj (.getResponseHeaders xhrio))))
 
 (defn xhrio-progress
   "Given an xhrio progress event, returns a map with keys :loaded and :total, where loaded is the
@@ -82,6 +83,7 @@
           (try
             {:transaction      tx
              :outgoing-request request
+             :headers          (xhrio-response-headers xhrio)
              :body             (xhrio-response-text xhrio)
              :status-code      (xhrio-status-code xhrio)
              :status-text      (xhrio-status-text xhrio)
@@ -92,6 +94,7 @@
               {:transaction      tx
                :outgoing-request request
                :body             ""
+               :headers          {}
                :status-code      0
                :status-text      "Internal Exception"
                :error            :exception

--- a/src/test/fulcro/client/network_spec.cljs
+++ b/src/test/fulcro/client/network_spec.cljs
@@ -60,7 +60,9 @@
             "Includes the original tx"
             (:transaction r) => [:a?]
             "Includes the outgoing request"
-            (:outgoing-request r) => {:a? false}))
+            (:outgoing-request r) => {:a? false}
+            "Transforms headers to clj map"
+            (:headers r) => {}))
         (finally
           (.dispose xhrio)))))
 


### PR DESCRIPTION
This PR enhances the client middleware slightly so that it includes the xhrio response headers as a clojure map.

One of my projects needed this functionality for reading custom authorization headers sent from a server, for example.