### PR TITLE
Do not mark a subform as changed if it was initialized with a nil value

### DIFF
--- a/src/main/fulcro/ui/form_state.cljc
+++ b/src/main/fulcro/ui/form_state.cljc
@@ -479,7 +479,7 @@
                                        current-value (cond
                                                        (map? items) (subform-ident k items)
                                                        (vector? items) (mapv #(subform-ident k %) items)
-                                                       :else [])
+                                                       :else items)
                                        has-tempids?  (if (every? util/ident? current-value)
                                                        (some #(prim/tempid? (second %)) current-value)
                                                        (prim/tempid? (second current-value)))]


### PR DESCRIPTION
Resolves the issue addressed in #295 