### PR TITLE
ensure that provided deps are listed in `pom.xml`

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -30,11 +30,11 @@
                                       binaryage/devtools          {:mvn/version "0.9.10"}
                                       org.clojure/tools.namespace {:mvn/version "0.3.0-alpha4"}}}
 
-           :provided   {:extra-deps {http-kit           {:mvn/version "2.3.0"}
-                                     ring/ring-core     {:mvn/version "1.6.3"}
-                                     bk/ring-gzip       {:mvn/version "0.3.0"}
-                                     bidi               {:mvn/version "2.1.5"}
-                                     com.taoensso/sente {:mvn/version "1.14.0-RC2"}}}
+           :provided   {:extra-deps {http-kit           {:mvn/version "2.3.0" :scope "provided"}
+                                     ring/ring-core     {:mvn/version "1.6.3" :scope "provided"}
+                                     bk/ring-gzip       {:mvn/version "0.3.0" :scope "provided"}
+                                     bidi               {:mvn/version "2.1.5" :scope "provided"}
+                                     com.taoensso/sente {:mvn/version "1.14.0-RC2" :scope "provided"}}}
 
            :workspaces {:extra-paths ["src/workspaces"]
                         :extra-deps {nubank/workspaces {:mvn/version "1.0.3"}}}

--- a/project.clj
+++ b/project.clj
@@ -14,4 +14,5 @@
 
   :plugins [[lein-tools-deps "0.4.1"]]
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
-  :lein-tools-deps/config {:config-files [:install :user :project]})
+  :lein-tools-deps/config {:config-files [:install :user :project]
+                           :aliases [:provided]})


### PR DESCRIPTION
This ensures that optional dependencies are properly declared in Fulcro's `pom.xml` with the scope `provided`. This means they will not be included when resolving dependencies but are still listed in `pom.xml`.

Quoting the [Maven docs](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope)

> **`provided`** This is much like `compile`, but indicates you expect the JDK or a container to provide the dependency at runtime. For example, when building a web application for the Java Enterprise Edition, you would set the dependency on the Servlet API and related Java EE APIs to scope `provided` because the web container provides those classes. This scope is only available on the compilation and test classpath, and is not transitive.

An alternative to using `:scope "provided"` would be to set `:optional true`, I didn't know about this for a long time and it seems less common than using `:scope "provided"`... the Maven documentation describes it like this:

> Optional dependencies - If project Y depends on project Z, the owner of project Y can mark project Z as an optional dependency, using the "optional" element. When project X depends on project Y, X will depend only on Y and not on Y's optional dependency Z. The owner of project X may then explicitly add a dependency on Z, at her option. (It may be helpful to think of optional dependencies as "excluded by default.")

Unfortunately some quick testing seems to indicate that the `:optional true` setting will not be carried over into the `pom.xml`. As far as I understand this would require a change in `lein-tools-deps` [here](https://github.com/RickMoynihan/lein-tools-deps/blob/d0d160ae8372b0bab148cdc50e6b0942c5792fb2/src/lein_tools_deps/lein_project.clj#L8-L15).

This PR will also fix analysis of Fulcro on https://cljdoc.org/d/fulcrologic/fulcro.

The easiest way to test this change is probably to generate one `pom.xml` in develop using `lein pom` and then generate one `pom.xml` in this branch, also using `lein pom`. Diffing them should result in the dependencies in `:provided` being added to `pom.xml` with the extra field `<scope>provided</scope>`.

Note that `bk/ring-gzip` seems to be included in the top level deps as well as in the `:provided` alias.