### PR TITLE
[feat] introduces a new namespace for db-helpers with basic utils

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/normalized_state_helpers.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/normalized_state_helpers.cljc
@@ -1,0 +1,309 @@
+(ns com.fulcrologic.fulcro.algorithms.normalized-state-helpers
+  "Functions that can be used against a normalized Fulcro state database."
+  #?(:cljs (:require-macros com.fulcrologic.fulcro.algorithms.normalized-state-helpers))
+  (:refer-clojure :exclude [get-in])
+  (:require
+    [clojure.set :as set]
+    [com.fulcrologic.fulcro.components :as comp :refer [defsc]]
+    #?(:clj  [com.fulcrologic.fulcro.dom-server :as dom]
+       :cljs [com.fulcrologic.fulcro.dom :as dom])
+    [edn-query-language.core :as eql]
+    [clojure.spec.alpha :as s]
+    [ghostwheel.core :refer [>defn =>]]
+    [com.fulcrologic.fulcro.algorithms.data-targeting :as targeting]
+    [com.fulcrologic.fulcro.algorithms.denormalize :as fdn]
+    [com.fulcrologic.fulcro.algorithms.merge :as merge]
+    [com.fulcrologic.fulcro.components :as comp]))
+
+(def integrate-ident*
+  "[state ident & named-parameters]
+
+  Integrate an ident into any number of places in the app state. This function is safe to use within mutation
+  implementations as a general helper function.
+
+  The named parameters can be specified any number of times. They are:
+
+  - append:  A vector (path) to a list in your app state where this new object's ident should be appended. Will not append
+  the ident if that ident is already in the list.
+  - prepend: A vector (path) to a list in your app state where this new object's ident should be prepended. Will not place
+  the ident if that ident is already in the list.
+  - replace: A vector (path) to a specific location in app-state where this object's ident should be placed. Can target a to-one or to-many.
+   If the target is a vector element then that element must already exist in the vector.
+
+  NOTE: `ident` does not have to be an ident if you want to place denormalized data.  It can really be anything.
+
+  Returns the updated state map."
+  targeting/integrate-ident*)
+
+(def remove-ident*
+  " [state-map ident path-to-idents]
+
+  Removes an ident, if it exists, from a list of idents in app state. This
+  function is safe to use within mutations."
+  merge/remove-ident*)
+
+
+(>defn tree-path->db-path
+  "Convert a 'denormalized' path into a normalized one by walking the path in state and honoring ident-based edges.
+
+  For example, one might find this to be true for a normalized db:
+
+  ```
+  state => {:person/id {1 {:person/id 1 :person/spouse [:person/id 3]}
+                        3 {:person/id 3 :person/first-name ...}}}
+
+  (tree-path->db-path state [:person/id 1 :person/spouse :person/first-name])
+  => [:person/id 3 :person/first-name]
+  ```
+  "
+  ([state path]
+   [map? vector? => vector?]
+   (loop [[h & t] path
+          new-path []]
+     (if h
+       (let [np (conj new-path h)
+             c (clojure.core/get-in state np)]
+         (if (eql/ident? c)
+           (recur t c)
+           (recur t (conj new-path h))))
+       (if (not= path new-path)
+         new-path
+         path)))))
+
+
+(>defn get-in
+  "Just like clojure.core/get-in, but if an element of the path is an ident it will follow the ident instead."
+  ([state-map path]
+   [map? vector? => any?]
+   (get-in state-map path nil))
+
+  ([state-map path not-found]
+   [map? vector? any? => any?]
+   (clojure.core/get-in state-map (tree-path->db-path state-map path) not-found)))
+
+
+(defn ui->props
+  "Obtain a tree of props for a UI instance from the current application state. Useful in mutations where you want
+  to denormalize an entity from the state database. `this` can often be obtained from the mutation `env` at the
+  `:component` key."
+  ([this]
+   (ui->props (comp/component->state-map this) (comp/react-type this) (comp/get-ident this)))
+  ([state-map component-class ident]
+   (fdn/db->tree (comp/get-query component-class state-map) (get-in state-map ident) state-map)))
+
+
+(defn- dissoc-in
+  "Dissociates an entry from a nested associative structure returning a new
+   nested structure. keys is a sequence of keys. Any empty maps that result
+   will not be present in the new structure."
+  [m [k & ks :as keys]]
+  (if ks
+    (if-let [nextmap (get m k)]
+      (let [newmap (dissoc-in nextmap ks)]
+        (if (seq newmap)
+          (assoc m k newmap)
+          (dissoc m k)))
+      m)
+    (dissoc m k)))
+
+
+(>defn remove-entity*
+  "Remove the given entity at the given ident. Also scans all tables and removes any to-one or to-many idents that are
+  found that match `ident` (removes dangling pointers to the removed entity).
+
+  The optional `cascade` parameter is a set of keywords that represent edges that should cause recursive deletes
+  (i.e. it indicates edge names that *own* something, indicating it is safe to remove those entities as well).
+
+  Returns the new state map with the entity(ies) removed."
+
+  ([state-map ident]
+   [map? eql/ident? => map?]
+   (remove-entity* state-map ident #{}))
+
+  ([state-map ident cascade]
+   [map? eql/ident? (s/coll-of keyword? :kind set?) => map?]
+
+   (let [;; "Walks the tree in a depth first manner and returns the normalized possible paths"
+         normalized-paths (letfn [(paths* [ps ks m]
+                                    (reduce-kv
+                                      (fn [ps k v]
+                                        (if (map? v)
+                                          (paths* ps (conj ks k) v)
+                                          (conj ps (conj ks k))))
+                                      ps
+                                      m))]
+                            (filter #(< (count %) 4)
+                                    (paths* () [] state-map)))
+
+         ident-specific-paths (fn [state ident]
+                                (filter (fn [a-path]
+                                          (let [vl (clojure.core/get-in state a-path)]
+                                            (if (coll? vl)
+                                              (or
+                                                (some #{ident} vl)
+                                                (= ident vl)))))
+                                        normalized-paths))
+
+         remove-ident-at-path (fn [state a-normalized-path ident]
+                                (let [v (clojure.core/get-in state a-normalized-path)]
+                                  (if (coll? v)
+                                    (cond
+                                      (= v ident) (dissoc-in state a-normalized-path)
+                                      (every? eql/ident? v) (merge/remove-ident* state ident a-normalized-path)
+                                      :else state)
+                                    state)))
+
+
+         remove-ident-from-tables (fn [state ident]
+                                    (reduce #(remove-ident-at-path %1 %2 ident)
+                                            state
+                                            (ident-specific-paths state ident)))
+
+         state-without-entity (->
+                                ;; remove pointers to the entity
+                                (remove-ident-from-tables state-map ident)
+                                ;; remove the top-level entity
+                                (dissoc-in ident))
+
+         target-entity (get-in state-map ident)
+
+         ;; Computed set of all affected entities when cascade option is provided
+         cascaded-idents (let [table-key (first ident)]
+                           (map
+                             (fn [entity-field]
+                               (clojure.core/get-in state-map
+                                                    (conj [table-key (table-key target-entity)] entity-field)))
+                             (set/intersection
+                               cascade
+                               (set (keys target-entity)))))
+
+         final-state (reduce
+                       (fn [state edge]
+                         (if (every? eql/ident? edge)
+                           (reduce (fn [new-state ident] (remove-entity* new-state ident cascade)) state edge)
+                           (remove-entity* state edge cascade)))
+                       state-without-entity
+                       cascaded-idents)]
+
+     final-state)))
+
+
+(>defn remove-edge*
+  "Remove the given edge at the given path. Also scans all tables and removes any to-one or to-many idents that are
+  found that match `edge` (removes dangling pointers to the removed entity(ies).
+
+  The optional `cascade` parameter is a set of keywords that represent edges that should cause recursive deletes
+  (i.e. it indicates edge names that *own* something, indicating it is safe to remove those entities as well).
+
+  Returns the new state map with the entity(ies) removed."
+
+  ([state-map path-to-edge]
+   [map? vector? => any?]
+   (remove-edge* state-map path-to-edge #{}))
+
+
+  ([state-map path-to-edge cascade]
+   [map? vector? (s/coll-of keyword? :kind set?) => map?]
+   (let [;; "Walks the tree in a depth first manner and returns the normalized possible paths"
+         normalized-paths (letfn [(paths* [ps ks m]
+                                    (reduce-kv
+                                      (fn [ps k v]
+                                        (if (map? v)
+                                          (paths* ps (conj ks k) v)
+                                          (conj ps (conj ks k))))
+                                      ps
+                                      m))]
+                            (filter #(< (count %) 4)
+                                    (paths* () [] state-map)))
+
+         candidate (let [vl (clojure.core/get-in state-map path-to-edge)]
+                     (if-not (vector? vl)
+                       nil
+                       (cond
+                         (eql/ident? vl) [vl]
+                         (every? eql/ident? vl) vl)))
+
+         final-state (if (some #{path-to-edge} normalized-paths)
+                       (reduce
+                         #(remove-entity* %1 %2 cascade)
+                         state-map
+                         candidate)
+                       state-map)]
+     final-state)))
+
+
+(>defn sort-idents-by
+  "Returns the sorted version of the provided vector of idents.
+
+  Intended to be used as
+  ```
+  (sort-idents-by :entity/field vector-of-idents)
+  ```
+
+  Can facilitate:
+  ```
+  (swap! state-map update-in [:entity 1 :list] #(sort-idents-by :list/field %))
+  ```
+  "
+  [entity-field vector-of-idents]
+  [keyword? vector? => any?]
+  (mapv first
+        (sort-by entity-field
+                 (map (fn [[k v]] {k v}) vector-of-idents))))
+
+
+(defn update-caller!
+  "Runs clojure.core/update on the table entry in the state database that corresponds
+   to the mutation caller (which can be explicitly set via `:ref` when calling `transact!`).
+
+   Equivalent to
+   ```
+   (swap! (:state env) update-in (:ref env) ...)
+   ```
+   "
+
+  [{:keys [state ref] :as mutation-env} & args]
+  (apply swap! state update-in ref args))
+
+
+(defn update-caller-in!
+  "Like swap! but starts at the ref from `env`, adds in supplied `path` elements
+  (resolving across idents if necessary). Finally runs an update-in on that resultant
+  path with the given `args`.
+
+   Equivalent to:
+   ```
+   (swap! (:state env) update-in (tree-path->db-path @state (into (:ref env) path)) args)
+   ```
+   with a small bit of additional sanity checking."
+
+  [{:keys [state ref] :as mutation-env} path & args]
+  (let [path (tree-path->db-path @state (into ref path))]
+    (if (and path (get-in @state path))
+      (apply swap! state update-in path args)
+      @state)))
+
+
+
+#?(:clj
+   (defmacro swap!->
+     "A useful macro for threading multiple operations together on the state map.
+
+     Equivalent to:
+     ```
+     (swap! (:state env) (fn [s] (-> s ...forms...)))
+     ```
+
+     For example
+     ```
+     (swap!-> env
+       (merge/merge-component ...)
+       (integrate-ident* ...))
+     ```
+     "
+     [mutation-env & forms]
+     `(swap! (:state ~mutation-env) (fn [s#]
+                                      (-> s#
+                                          ~@forms)))))
+
+

--- a/src/test/com/fulcrologic/fulcro/algorithms/normalized_state_helpers_spec.cljc
+++ b/src/test/com/fulcrologic/fulcro/algorithms/normalized_state_helpers_spec.cljc
@@ -1,0 +1,435 @@
+(ns com.fulcrologic.fulcro.algorithms.normalized-state-helpers-spec
+  (:require
+    [fulcro-spec.core :refer [assertions specification component when-mocking behavior]]
+    [com.fulcrologic.fulcro.components :as comp :refer [defsc]]
+    [com.fulcrologic.fulcro.algorithms.normalized-state-helpers :as nsh]))
+
+(specification "tree-path->db-path"
+
+  (behavior "Resolves top-level to-one references"
+    (let [state {:fastest-car [:car/id 1]
+                 :car/id      {1 {:car/model "model-1"}
+                               2 {:car/model "model-2"}}}]
+      (assertions
+        (nsh/tree-path->db-path state [:fastest-car])
+        => [:car/id 1])))
+
+  (behavior "Resolves top-level to-many references"
+    (let [state {:grandparents [[:person/id 1] [:person/id 2]]
+                 :person/id    {1 {:person/name "person-1"}
+                                2 {:person/name "person-2"}}}]
+      (assertions
+        (nsh/tree-path->db-path state [:grandparents 1])
+        => [:person/id 2])))
+
+  (behavior "Resolves table-nested to-one references"
+    (let [state {:person/id {1 {:person/name  "person-1"
+                                :person/email [:email/id 1]}
+                             2 {:person/name  "person-2"
+                                :person/email [:email/id 2]}}
+                 :email/id  {1 {:email/provider "Google"}}}]
+      (assertions
+        (nsh/tree-path->db-path state [:person/id 1 :person/email])
+        => [:email/id 1])))
+
+  (behavior "Resolves table-nested to-many references"
+    (let [state {:person/id {1 {:person/name "person-1"
+                                :person/cars [[:car/id 1] [:car/id 2]]}
+                             2 {:person/name "person-2"
+                                :person/cars [[:car/id 1]]}}
+                 :car/id    {1 {:car/model "model-1"}
+                             2 {:car/model "model-2"}}}]
+      (assertions
+        (nsh/tree-path->db-path state [:person/id 1 :person/cars 0])
+        => [:car/id 1]))))
+
+
+(specification "get-in"
+  (behavior "Follows edges from root that are normalized"
+    (let [state {:person/id {1 {:person/name "person-1"}
+                             2 {:person/name "person-2"}}}]
+      (assertions
+        (get-in state [:person/id 1 :person/name]) => "person-1")))
+
+  (behavior "Behaves like clojure.core/get-in for denormalized data"
+    (let [denorm-data {:a [[:b 1]] :b [:b 1]}
+          state {:denorm {:level-1 {:level-2 denorm-data}}}]
+      (assertions
+        (nsh/get-in state [:denorm :level-1 :level-2]) => denorm-data)))
+
+  (behavior "Returns nil when the value isn't found"
+    (let [state {:person/id {1 {:person/name "person-1"
+                                :person/cars [[:car/id 1] [:car/id 2]]}
+                             2 {:person/name "person-2"
+                                :person/cars [[:car/id 1]]}}}]
+      (assertions
+        (nsh/get-in state [:person/id 1 :person/email]) => nil
+        (nsh/get-in state [:car/id 1]) => nil)))
+
+
+  (behavior "Returns not-found when provided this option"
+    (let [state {:person/id {1 {:person/name  "person-1"
+                                :person/email [:email/id 1]}
+                             2 {:person/name  "person-2"
+                                :person/email [:email/id 2]}}}]
+      (assertions
+        (nsh/get-in state [:person/id 3 :person/name] "not-found") => "not-found"))))
+
+
+(defsc Person [this {:keys [:person/id :person/name :person/children] :as props}]
+  {:query [:person/id :person/name {:person/children '...}]
+   :ident :person/id})
+
+(specification "ui->props"
+  (behavior "Pulls the props from the component given the app state"
+    (let [state {:person/id {1 {:person/id 1 :person/name "Dad" :person/children [[:person/id 2] [:person/id 3]]}
+                             2 {:person/id 2 :person/name "Son"}
+                             3 {:person/id 3 :person/name "Daughter"}}}]
+      (assertions
+        (nsh/ui->props state Person [:person/id 1]) => {:person/id       1 :person/name "Dad"
+                                                        :person/children [{:person/id 2 :person/name "Son"}
+                                                                          {:person/id 3 :person/name "Daughter"}]}))))
+
+(specification "remove-entity*"
+  (behavior "Without cascading"
+    (let [denorm-data {:a [[:person/id 1] [:person/id 2]]
+                       :b [:person/id 1]}
+
+          state {:fastest-car  [:car/id 1]
+                 :grandparents [[:person/id 1] [:person/id 2]]
+                 :denorm       {:level-1 {:level-2 denorm-data}}
+                 :person/id    {1 {:person/id    1
+                                   :person/email [:email/id 1]
+                                   :person/cars  [[:car/id 1]
+                                                  [:car/id 2]]}
+                                2 {:person/id 2}}
+                 :car/id       {1 {:car/id 1}
+                                2 {:car/id 2}}
+                 :email/id     {1 {:email/id 1}}}]
+      (assertions
+        "Removes the entity itself from the database"
+        (-> (nsh/remove-entity* state [:person/id 1])
+            (nsh/get-in [:person/id 1])) => nil
+        "Removes top-level to-one references"
+        (-> (nsh/remove-entity* state [:car/id 1]) :fastest-car) => nil
+        "Removes top-level to-many refs"
+        (-> (nsh/remove-entity* state [:person/id 1]) :grandparents) => [[:person/id 2]]
+        "Ignores denormalized data"
+        (-> (nsh/remove-entity* state [:person/id 1])
+            (nsh/get-in [:denorm :level-1 :level-2])) => denorm-data
+        "Removes table-nested to-one references"
+        (let [new-state (nsh/remove-entity* state [:email/id 1])]
+          (-> (or
+                (clojure.core/get-in new-state [:person/id 1 :person/email])
+                (nsh/get-in new-state [:person/id 1 :person/email]))
+              nil?)) => true
+        "Removes table-nested to-many refs"
+        (-> (nsh/remove-entity* state [:car/id 1])
+            (nsh/get-in [:person/id 1 :person/cars])) => [[:car/id 2]])))
+
+
+
+  (behavior "With cascading, non-recursive behavior"
+    (let [state {:person/id {1 {:person/id    1
+                                :person/email [:email/id 1]
+                                :person/cars  [[:car/id 1]
+                                               [:car/id 2]]}
+                             2 {:person/id 2}}
+                 :car/id    {1 {:car/id 1}
+                             2 {:car/id 2}}
+                 :email/id  {1 {:email/id 1}}}]
+      (assertions
+        "Removes a single, to-one and non-recursive cascased entity"
+        (let [new-state (nsh/remove-entity* state [:person/id 1] #{:person/email})]
+          (->
+            (or
+              (nsh/get-in new-state [:person/id 1])
+              (nsh/get-in new-state [:email/id 1]))
+            nil?)) => true
+
+        "Removes a single, to-many and non-recursive cascased entity"
+        (let [new-state (nsh/remove-entity* state [:person/id 1] #{:person/cars})]
+          (or
+            (nsh/get-in new-state [:person/id 1])
+            (nsh/get-in new-state [:car/id 1])
+            (nsh/get-in new-state [:car/id 2]))) => nil
+
+        "Removes multiple, to-one and non-recursive cascased entity"
+        (let [new-state (nsh/remove-entity* state [:person/id 1]
+                                            #{:person/email :person/cars})]
+          (or
+            (nsh/get-in new-state [:person/id 1])
+            (nsh/get-in new-state [:email/id 1])
+            (nsh/get-in new-state [:car/id 1])
+            (nsh/get-in new-state [:car/id 2]))) => nil)))
+
+  (behavior "With cascading, recursive behavior"
+    (let [state {:person/id {1 {:person/id       1
+                                :person/spouse   [:person/id 2]
+                                :person/children [[:person/id 3]]}
+                             2 {:person/id       2
+                                :person/spouse   [:person/id 1]
+                                :person/children [[:person/id 3]]}
+                             3 {:person/id 3}}}]
+      (assertions
+        "Removes a single, to-many cascased entities"
+        (let [new-state (nsh/remove-entity* state [:person/id 1] #{:person/children})]
+          (or
+            (nsh/get-in new-state [:person/id 1])
+            (nsh/get-in new-state [:person/id 3]))) => nil
+
+        "Removes multiple, to-many cascased entities"
+        (let [new-state (nsh/remove-entity* state [:person/id 1]
+                                            #{:person/children :person/spouse})]
+          (or
+            (get new-state [:person/id 2])
+            (get new-state [:person/id 3]))) => nil))))
+
+
+(specification "remove-edge*"
+
+  (behavior "Without cascading"
+    (let [state {:fastest-car    [:car/id 1]
+                 :denorm         {:level-1 {:level-2 {:a [[:person/id 1] [:person/id 2]]
+                                                      :b [:person/id 1]}}}
+                 :favourite-cars [[:car/id 1] [:car/id 2]]
+                 :car/id         {1 {:car/registered-owner [:person/id 1]}
+                                  2 {:car/registered-owner [:person/id 1]}}
+                 :person/id      {1 {:person/age        42
+                                     :person/cars       [[:car/id 1] [:car/id 2]]
+                                     :person/address    [:address/id 1]
+                                     :alternate-address [:address/id 2]}}
+                 :address/id     {1 {:address/state "Oregon"}
+                                  2 {:address/state "Idaho"}}}]
+      (assertions
+
+
+        "Refuses to remove a denormalized edge"
+        (nsh/remove-edge* state [:denorm :level-1 :level2 :b]) => state
+
+        "Refuses to remove a non-edge"
+        (nsh/remove-edge* state [:person/id 1 :person/age]) => state
+
+        "Removes top-level to-one edge"
+        (let [new-state (nsh/remove-edge* state [:fastest-car])]
+          (or
+            (get-in new-state [:car/id 1])
+            (get-in new-state [:fastest-car]))) => nil
+
+        "Removes top-level to-many edge"
+        (let [new-state (nsh/remove-edge* state [:favourite-cars])]
+          (or
+            (get-in new-state [:car/id 1])
+            (get-in new-state [:car/id 2])
+            (get-in new-state [:favourite-cars]))) => []
+
+        "Removes table-nested to-one edge"
+        (let [new-state (nsh/remove-edge* state [:person/id 1 :person/address])]
+          (or
+            (get-in new-state [:address/id 1])
+            (get-in new-state [:person/id 1 :person/address]))) => nil
+
+        "Removes table-nested to-many edge"
+        (let [new-state (nsh/remove-edge* state [:person/id 1 :person/cars])]
+          (or
+            (get-in new-state [:car/id 1])
+            (get-in new-state [:car/id 2])
+            (get-in new-state [:person/id 1 :person/cars]))) => [])))
+
+  (behavior "With to-one cascaded edge removal"
+    (let [state {:person/id      {1 {:person/id   1
+                                     :latest-car  [:car/id 2]
+                                     :person/cars [[:car/id 1] [:car/id 2]]}
+                                  2 {:person/id 2}}
+                 :fastest-car    [:car/id 1]
+                 :favourite-cars [[:car/id 1] [:car/id 2]]
+                 :car/id         {1 {:car/id     1
+                                     :car/engine [:engine/id 1]}
+                                  2 {:car/id     2
+                                     :car/engine [:engine/id 2]}}
+                 :engine/id      {1 {:engine/id 1}
+                                  2 {:engine/id 2}}}]
+
+      (assertions
+
+        "Removes top-level to-one edge"
+        (let [new-state (nsh/remove-edge* state [:fastest-car] #{:car/engine})]
+          (-> (or
+                (get-in new-state [:car/id 1])
+                (get-in new-state [:engine/id 1]))
+              nil?)) => true
+
+
+        "Removes top-level to-many edge"
+        (let [new-state (nsh/remove-edge* state [:favourite-cars] #{:car/engine})]
+          (-> (or
+                (get-in new-state [:car/id 1])
+                (get-in new-state [:engine/id 1])
+                (get-in new-state [:car/id 2])
+                (get-in new-state [:engine/id 2]))
+              nil?)) => true
+
+
+        "Removes table-nested to-one edge"
+        (let [new-state (nsh/remove-edge* state [:person/id 1 :latest-car] #{:car/engine})]
+          (-> (or
+                (get-in new-state [:engine/id 2])
+                (get-in new-state [:car/id 2]))
+              nil?)) => true
+
+
+        "Removes table-nested to-many edge"
+        (let [new-state (nsh/remove-edge* state [:person/id 1 :person/cars] #{:car/engine})]
+          (-> (or
+                (get-in new-state [:car/id 1])
+                (get-in new-state [:engine/id 1])
+                (get-in new-state [:car/id 2])
+                (get-in new-state [:engine/id 2]))
+              nil?)) => true)))
+
+
+  (behavior "With to-many cascaded edge removal"
+    (let [state {:person/id      {1 {:person/id   1
+                                     :latest-car  [:car/id 2]
+                                     :person/cars [[:car/id 1] [:car/id 2]]}}
+                 :fastest-car    [:car/id 1]
+                 :favourite-cars [[:car/id 1] [:car/id 2]]
+                 :car/id         {1 {:car/id     1
+                                     :car/colors [[:color/id 1]]}
+                                  2 {:car/id     2
+                                     :car/colors [[:color/id 1]
+                                                  [:color/id 2]]}}
+                 :color/id       {1 {:color/id 1}
+                                  2 {:color/id 2}}}]
+
+      (assertions
+
+        "Removes top-level to-one edge"
+        (let [new-state (nsh/remove-edge* state [:fastest-car] #{:car/colors})]
+          (-> (or
+                (get-in new-state [:car/id 1])
+                (get-in new-state [:color/id 1]))
+              nil?)) => true
+
+
+        "Removes top-level to-many edge"
+        (let [new-state (nsh/remove-edge* state [:favourite-cars] #{:car/colors})]
+          (-> (or
+                (get-in new-state [:car/id 1])
+                (get-in new-state [:color/id 1])
+                (get-in new-state [:car/id 2])
+                (get-in new-state [:color/id 2]))
+              nil?)) => true
+
+
+        "Removes table-nested to-one edge"
+        (let [new-state (nsh/remove-edge* state [:person/id 1 :latest-car] #{:car/colors})]
+          (-> (or
+                (get-in new-state [:car/id 2])
+                (get-in new-state [:color/id 1])
+                (get-in new-state [:color/id 2]))
+              nil?)) => true
+
+
+        "Removes table-nested to-many edge"
+        (let [new-state (nsh/remove-edge* state [:person/id 1 :person/cars] #{:car/colors})]
+          (-> (or
+                (get-in new-state [:car/id 1])
+                (get-in new-state [:color/id 1])
+                (get-in new-state [:car/id 2])
+                (get-in new-state [:color/id 2]))
+              nil?)) => true))))
+
+
+(specification "sort-idents-by"
+  (behavior "Given a vector of idents and sorting parameter"
+    (let [state (atom {:person/id {1 {:person/name              "person-1"
+                                      :person/age               90
+                                      :person/random-collection [[:person/id 3]
+                                                                 [:car/id 9]
+                                                                 [:person/id 5]
+                                                                 [:car/id 5]
+                                                                 [:person/id 1]]
+
+                                      :person/children          [[:person/id 3]
+                                                                 [:person/id 9]
+                                                                 [:person/id 5]
+                                                                 [:person/id 1]]}}})]
+
+      (assertions
+        "Returns an ordered vector of idents"
+        (nsh/sort-idents-by :person/id (get-in @state [:person/id 1 :person/children]))
+        => [[:person/id 1] [:person/id 3] [:person/id 5] [:person/id 9]]
+
+        "Ignores the idents different from the sorting parameter"
+        (nsh/sort-idents-by :person/id (get-in @state [:person/id 1 :person/random-collection]))
+        => [[:car/id 9] [:car/id 5] [:person/id 1] [:person/id 3] [:person/id 5]]))))
+
+
+(specification "update-caller!"
+  (behavior "Updates the app state wrt caller"
+    (let [mutation-env {:ref   [:person/id 1]
+                        :state (atom {:person/id {1 {:person/id   1
+                                                     :latest-car  [:car/id 2]
+                                                     :person/cars [[:car/id 1] [:car/id 2]]}}
+                                      :car/id    {1 {:car/id 1}
+                                                  2 {:car/id 2}}})}]
+      (assertions
+        "Correctly handles assoc-in"
+        (-> (nsh/update-caller! mutation-env
+                                assoc-in [:latest-car] [:car/id 3])
+            (get-in [:person/id 1 :latest-car])) => [:car/id 3]
+
+        "Correctly handles dissoc'ing"
+        (-> (nsh/update-caller! mutation-env
+                                dissoc :latest-car)
+            (get-in [:latest-car])
+            nil?) => true
+
+        "Correctly handles assoc'ing"
+        (-> (nsh/update-caller! mutation-env assoc :person/name "Bob")
+            (get-in [:person/id 1 :person/name])) => "Bob"))))
+
+
+(specification "update-caller-in!"
+  (behavior "Updates the app state wrt caller"
+    (let [mutation-env {:ref   [:person/id 1]
+                        :state (atom {:person/id      {1 {:person/id   1
+                                                          :latest-car  [:car/id 2]
+                                                          :person/cars [[:car/id 1] [:car/id 2]]}}
+                                      :fastest-car    [:car/id 1]
+                                      :favourite-cars [[:car/id 1] [:car/id 2]]
+                                      :car/id         {1 {:car/id     1
+                                                          :car/colors [[:color/id 1]]}
+                                                       2 {:car/id     2
+                                                          :car/colors [[:color/id 1]
+                                                                       [:color/id 2]]}}})}]
+      (assertions
+        "Follows a to-one ident and updates entity"
+        (-> (nsh/update-caller-in! mutation-env [:latest-car]
+                                   assoc :car/engine "Rolls Royce")
+            (nsh/get-in [:car/id 2 :car/engine])) => "Rolls Royce"
+
+        "Follows a to-many ident and updates entity"
+        (-> (nsh/update-caller-in! mutation-env [:person/cars 1]
+                                   assoc-in [:car/colors 1] [:color/id 3])
+            (nsh/get-in [:car/id 2 :car/colors])) => [[:color/id 1] [:color/id 3]]))))
+
+
+(specification "swap!->"
+  (behavior "Thread map operations "
+    (let [mutation-env {:state (atom {:person/id {1 {:person/id   1
+                                                     :latest-car  [:car/id 2]
+                                                     :person/cars [[:car/id 1] [:car/id 2]]}}
+                                      :car/id    {1 {:car/id     1
+                                                     :car/colors [[:color/id 1]]}
+                                                  2 {:car/id     2
+                                                     :car/colors [[:color/id 1]
+                                                                  [:color/id 2]]}}})}]
+
+      (assertions
+        "Threads table-nested operations on state atom"
+        (-> (nsh/swap!-> mutation-env
+                         (assoc-in [:person/id 1 :person/age] 42)
+                         (update-in [:person/id 1 :person/age] inc))
+            (nsh/get-in [:person/id 1 :person/age])) => 43))))


### PR DESCRIPTION
This PR adds a new namespace to the `algorithms`, namely `com.fulcrologic.fulcro.algorithms.normalized-state-helpers` as well as the corresponding test suite `com.fulcrologic.fulcro.algorithms.normalized-state-helpers-spec`.

A brief index of the utility functions is as follows

- `integrate-ident*`
- `remove-ident*`
- `tree-path->db-path`
- `get-in`
- `ui->props`
- `remove-entity*`
- `remove-edge*`
- `sort-idents-by`
- `update-caller!`
- `update-caller-in!`
- `swap!->`






For reference, this PR takes some code from the [WIP] https://github.com/abhi18av/fulcro/pull/2  and https://github.com/abhi18av/fulcro/pull/4 in order to get the ball rolling. 

