### PR TITLE
[chore] updates the URL for the new github location for fulcro repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:fulcrologic/fulcro3.git"
+    "url": "git@github.com:fulcrologic/fulcro.git"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Let me know if the older `fulcro3` git url serves some purpose, in which case this PR can be closed.