### PR TITLE
Node requestAnimationFrame reference error fix

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/scheduling.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/scheduling.cljc
@@ -40,7 +40,7 @@
    (schedule! app scheduled-key action 0)))
 
 (let [raf #?(:clj #(defer % 16)
-             :cljs (if js/requestAnimationFrame
+             :cljs (if (exists? js/requestAnimationFrame)
                      js/requestAnimationFrame
                      #(defer % 16)))]
   (defn schedule-animation!


### PR DESCRIPTION
Unlike the browser, node throws a reference error if a value (like `js/requestAnimationFrame`) is not defined. Need to use `exists?`.

The code used to do this correctly but it got dropped in this commit.

https://github.com/fulcrologic/fulcro/commit/62e7991f68bb4f9798d71ee5db82eb8cd90d636c#diff-22864e11345f647275cef1ae9ca34108L56