### PR TITLE
Revert order merge-ident and merge-tree order again.

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/merge.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/merge.cljc
@@ -273,7 +273,9 @@
               (let [component-query (get ident-joins ident '[*])
                     normalized-data (fnorm/tree->db component-query props false (pre-merge-transform tree options))
                     refs            (meta normalized-data)]
-                (merge-ident (merge-tree result-tree refs) ident normalized-data)))]
+                (-> result-tree
+                    (merge-ident ident normalized-data)
+                    (merge-tree refs))))]
       (reduce step tree refs))))
 
 (defn merge*

--- a/src/test/com/fulcrologic/fulcro/algorithms/merge_spec.cljc
+++ b/src/test/com/fulcrologic/fulcro/algorithms/merge_spec.cljc
@@ -286,7 +286,17 @@
       {:remove-missing? true})
     => {:id {42 {:id          42
                  :child/value 321
-                 :child       [:id 42]}}}))
+                 :child       [:id 42]}}}
+
+    "merge parent and children new data"
+    (merge/merge* {} [{[:id 42] (comp/get-query UiPreMergePlaceholderRoot)}]
+      {[:id 42] {:id    42
+                 :child {:id          42
+                         :child/value 123}}}
+      {:remove-missing? true})
+    => {:id {42 {:id          42
+                 :child       [:id 42]
+                 :child/value 123}}}))
 
 (specification "merge-component"
   (let [component-tree   (person :tony "Tony" [(phone-number 1 "555-1212") (phone-number 2 "123-4555")])


### PR DESCRIPTION
When I was developing I found the bug that's demonstrated by the new test case, the result with current code is that the new data from the child is not merged when its a placeholder. After some testing I realised that the original order now works fine on both previous failure case and this new one, due to the mark/sweep removal on the pre-merge step. So this can now work as it was in Fulcro 2.