### PR TITLE
added optional channel-type to c.f.f.i.inspect-ws/start-ws-messaging

### DIFF
--- a/src/main/com/fulcrologic/fulcro/inspect/inspect_ws.cljs
+++ b/src/main/com/fulcrologic/fulcro/inspect/inspect_ws.cljs
@@ -27,11 +27,12 @@
 
 (def backoff-ms #(enc/exp-backoff % {:max 1000}))
 
-(defn start-ws-messaging! []
+(defn start-ws-messaging!
+  [& [{:keys [channel-type] :or {channel-type :auto}}]]
   (when-not @sente-socket-client
     (reset! sente-socket-client
       (sente/make-channel-socket-client! "/chsk" "no-token-desired"
-        {:type           :auto
+        {:type           channel-type
          :host           SERVER_HOST
          :port           SERVER_PORT
          :packer         (make-packer {:read  inspect.transit/read-handlers


### PR DESCRIPTION
Added optional `channel-type` param, which would allow to remove error when connecting to Inspect Electron from React Native.