### PR TITLE
fix pristine->entity* to remove keys that got added after pristine

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/form_state.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/form_state.cljc
@@ -550,8 +550,13 @@
   Only affects declared fields and sub-forms."
   [state-map entity-ident]
   [map? eql/ident? => map?]
-  (update-forms state-map (fn reset-form-step [e {:keys [::pristine-state] :as config}]
-                            [(merge e pristine-state) config]) entity-ident))
+  (update-forms state-map
+    (fn reset-form-step [e {:keys [::pristine-state ::fields] :as config}]
+      (let [new-e (merge e pristine-state)
+            elide-keys (clojure.set/difference fields (keys pristine-state))
+            new-e (apply dissoc new-e elide-keys)]
+        [new-e config]))
+    entity-ident))
 
 (>defn entity->pristine*
   "Overwrite the pristine state (form state's copy) of the entity. This is meant to be used from a mutation

--- a/src/main/com/fulcrologic/fulcro/algorithms/form_state.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/form_state.cljc
@@ -20,6 +20,7 @@
     [edn-query-language.core :as eql]
     [com.fulcrologic.guardrails.core :refer [>def >defn >defn- =>]]
     [com.fulcrologic.fulcro.algorithms.tempid :as tempid]
+    [com.fulcrologic.fulcro.algorithms.merge :refer [merge-elide-keys]]
     [com.fulcrologic.fulcro.mutations :refer [defmutation]]
     [com.fulcrologic.fulcro.components :as comp :refer [defsc]]))
 
@@ -552,11 +553,7 @@
   [map? eql/ident? => map?]
   (update-forms state-map
     (fn reset-form-step [e {:keys [::pristine-state ::fields] :as config}]
-      (let [new-e (merge e pristine-state)
-            elide-keys (clojure.set/difference fields (keys pristine-state))
-            new-e (apply dissoc new-e elide-keys)]
-        [new-e config]))
-    entity-ident))
+      [(merge-elide-keys e pristine-state fields) config]) entity-ident))
 
 (>defn entity->pristine*
   "Overwrite the pristine state (form state's copy) of the entity. This is meant to be used from a mutation

--- a/src/main/com/fulcrologic/fulcro/algorithms/merge.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/merge.cljc
@@ -7,6 +7,7 @@
     [com.fulcrologic.fulcro.algorithms.normalize :as fnorm]
     [com.fulcrologic.fulcro.algorithms.denormalize :as fdn]
     [com.fulcrologic.fulcro.algorithms.do-not-use :as util]
+    [com.fulcrologic.guardrails.core :refer [>def >defn >defn- =>]]
     [edn-query-language.core :as eql]
     [taoensso.timbre :as log]))
 
@@ -477,3 +478,16 @@
   (let [app (comp/any->app app)]
     (merge-alternate-unions (partial merge-component! app) root-component)))
 
+(>defn merge-elide-keys
+  "replace a subset of m1's keys ks with m2's, eliding any missing"
+  ([m1 m2 ks]
+   [map? map? set? => map?]
+   (persistent!
+     (reduce-kv
+       (fn [out k v]
+         (if (not (contains? ks k))
+           (assoc! out k v)
+           (if (contains? m2 k)
+             (assoc! out k (k m2))
+             out)))
+       (transient {}) m1))))

--- a/src/test/com/fulcrologic/fulcro/algorithms/form_state_spec.cljc
+++ b/src/test/com/fulcrologic/fulcro/algorithms/form_state_spec.cljc
@@ -315,7 +315,8 @@
       (let [modified-state-map (-> state-map
                                  (assoc-in [:phone/id 3 ::phone-number] "111")
                                  (assoc-in [:locale/by-id 22 ::country] :UK)
-                                 (assoc-in [:person/id 1 ::person-name] "Bobby"))
+                                 (assoc-in [:person/id 1 ::person-name] "Bobby")
+                                 (assoc-in [:person/id 1 ::person-age] 42))
             reset-state-map    (fs/pristine->entity* modified-state-map [:person/id 1])]
         (assertions
           (not= modified-state-map state-map) => true


### PR DESCRIPTION
This fixes the problem where a form adds keys that were missing when pristine was created, but then attempts to reset.  Currently the reset will fail because `pristine->entity*` only merges pristine back into the entity and leaves the new keys, which leaves the form in a dirty state.