### PR TITLE
Error if get-query in :query outside of a join

### DIFF
--- a/src/test/com/fulcrologic/fulcro/macros/defsc_spec.clj
+++ b/src/test/com/fulcrologic/fulcro/macros/defsc_spec.clj
@@ -53,6 +53,10 @@
           (#'defsc/build-query-forms nil 'X 'this '{:keys [db/id person/nme person/job]}
             {:template '[:db/id :person/name {:person/job (defsc/get-query Job)}]}))
       "Verifies the propargs matches queries data when not a symbol")
+    (is (thrown-with-msg? ExceptionInfo #"defsc X: `get-query` calls in :query can only be inside a join value.*"
+          (#'defsc/build-query-forms nil 'X 'this '{:keys [db/id person/job]}
+            {:template '[:db/id :person/job (defsc/get-query Job)]}))
+        "Verifies the propargs matches queries data when not a symbol")
     (assertions
       "Support a method form"
       (#'defsc/build-query-forms nil 'X 'this 'props {:method '(fn [] [:db/id])})


### PR DESCRIPTION
E.g. `:query [:my/key (comp/get-query MyChild)]` will fail with

> defsc MyComponent: `get-query` calls in :query can only be inside a join value,
> i.e. `{:some/key (comp/get-query Header)}` at ...

Note: I do not include the preceeding key so that I also catch
`:query [(get-query AnotherChild)]` and b/c I cannot know whether
it is intended as a key for the join or an unrelated property.