### PR TITLE
Always use http to connect in fulcro inspect websockets

### DIFF
--- a/src/main/com/fulcrologic/fulcro/inspect/inspect_ws.cljs
+++ b/src/main/com/fulcrologic/fulcro/inspect/inspect_ws.cljs
@@ -35,6 +35,7 @@
         {:type           channel-type
          :host           SERVER_HOST
          :port           SERVER_PORT
+         :protocol       :http
          :packer         (make-packer {:read  inspect.transit/read-handlers
                                        :write inspect.transit/write-handlers})
          :wrap-recv-evs? false


### PR DESCRIPTION
So in electron, in which the URL is `file://`, this makes it work there.