### PR TITLE
Use only-refresh when triggering toggle! or set-value!

### DIFF
--- a/src/main/com/fulcrologic/fulcro/mutations.cljc
+++ b/src/main/com/fulcrologic/fulcro/mutations.cljc
@@ -250,15 +250,19 @@
 (defn toggle!
   "Toggle the given boolean `field` on the specified component. It is recommended you use this function only on
   UI-related data (e.g. form checkbox checked status) and write clear top-level transactions for anything more complicated."
-  [comp field]
-  (comp/transact!! comp `[(toggle {:field ~field})] {:compressible? true}))
+  [component field]
+  (comp/transact!! component `[(toggle {:field ~field})]
+    {:compressible? true
+     :only-refresh  [(comp/get-ident component)]}))
 
 (defn set-value!
   "Set a raw value on the given `field` of a `component`. It is recommended you use this function only on
   UI-related data (e.g. form inputs that are used by the UI, and not persisted data). Changes made via these
   helpers are compressed in the history."
   [component field value]
-  (comp/transact!! component `[(set-props ~{field value})] {:compressible? true}))
+  (comp/transact!! component `[(set-props ~{field value})]
+    {:compressible? true
+     :only-refresh  [(comp/get-ident component)]}))
 
 #?(:cljs
    (defn- ensure-integer


### PR DESCRIPTION
While testing performance under large collections, this simple change has a significant impact.

Running without `:only-refresh`

<img width="898" alt="v25nfS-XVQ" src="https://user-images.githubusercontent.com/25736/81117260-a24a9400-8edb-11ea-8744-c929286bf7e3.png">

Running with `:only-refresh`

<img width="902" alt="GlLZCALGlT" src="https://user-images.githubusercontent.com/25736/81117272-a8407500-8edb-11ea-9056-a8cb1de061aa.png">