### PR TITLE
fix misplaced docstrings

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/do_not_use.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/do_not_use.cljc
@@ -67,8 +67,9 @@
   #?(:clj  (java.util.Date.)
      :cljs (js/Date.)))
 
-(defn deep-merge [& xs]
+(defn deep-merge
   "Merges nested maps without overwriting existing keys."
+  [& xs]
   (if (every? map? xs)
     (apply merge-with deep-merge xs)
     (last xs)))

--- a/src/main/com/fulcrologic/fulcro/algorithms/merge.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/merge.cljc
@@ -146,7 +146,7 @@
 
                   :else result))) result query)))
 
-(defn mark-missing [result query]
+(defn mark-missing
   "Recursively walk the query and response marking anything that was *asked for* in the query but is *not* in the response as missing.
   The sweep-merge process (which happens later in the plumbing) uses these markers as indicators to remove any existing
   data in the target of the merge (i.e. your state database).
@@ -156,6 +156,7 @@
   Returns the result with missing markers in place (which are then used/removed in a later stage).
 
   See the Developer Guide section on Fulcro's merge process for more information."
+  [result query]
   (try
     (mark-missing-impl result query)
     (catch #?(:clj Exception :cljs :default) e

--- a/src/todomvc/fulcro_todomvc/ui.cljs
+++ b/src/todomvc/fulcro_todomvc/ui.cljs
@@ -15,8 +15,9 @@
 (defn is-enter? [evt] (= 13 (.-keyCode evt)))
 (defn is-escape? [evt] (= 27 (.-keyCode evt)))
 
-(defn trim-text [text]
+(defn trim-text
   "Returns text without surrounding whitespace if not empty, otherwise nil"
+  [text]
   (let [trimmed-text (clojure.string/trim text)]
     (when-not (empty? trimmed-text)
       trimmed-text)))

--- a/src/todomvc/fulcro_todomvc/ui_with_legacy_ui_routers.cljs
+++ b/src/todomvc/fulcro_todomvc/ui_with_legacy_ui_routers.cljs
@@ -13,8 +13,9 @@
 (defn is-enter? [evt] (= 13 (.-keyCode evt)))
 (defn is-escape? [evt] (= 27 (.-keyCode evt)))
 
-(defn trim-text [text]
+(defn trim-text
   "Returns text without surrounding whitespace if not empty, otherwise nil"
+  [text]
   (let [trimmed-text (clojure.string/trim text)]
     (when-not (empty? trimmed-text)
       trimmed-text)))


### PR DESCRIPTION
A few docsctrings are placed after the binding form in the source code.