### PR TITLE
get-computed: mention it "doesn't work" if nil props

### DIFF
--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -175,7 +175,7 @@
         (not (empty? computed-map)) (assoc :fulcro.client.primitives/computed computed-map)))))
 
 (defn get-computed
-  "Return the computed properties on a component or its props."
+  "Return the computed properties on a component or its props. Note that it requires that the normal properties are not nil."
   ([x]
    (get-computed x []))
   ([x k-or-ks]


### PR DESCRIPTION
I just spent quite a while trying to find out why my computed props are nil. It haven't crossed my mind for a while that there is a problem with the standard props. I hope this comment might save time someone in a similar situation.