### PR TITLE
Fix in HTTP remote

### DIFF
--- a/src/main/com/fulcrologic/fulcro/networking/http_remote.cljs
+++ b/src/main/com/fulcrologic/fulcro/networking/http_remote.cljs
@@ -122,7 +122,7 @@
       (log/error "Attempt to request alternate response from HTTP remote from multiple items in a single transaction. This could mean more than one transaction got combined into a single request."))
     (if (and alt (= 1 cnt) (contains? legal-response-types alt))
       (let [node         (update-in (first nodes) [:params] dissoc ::response-type)
-            updated-body [(eql/ast->query node)]]
+            updated-body (eql/ast->query node)]
         [updated-body alt])
       [body :default])))
 


### PR DESCRIPTION
`eql/ast->query` already returns a valid EQL query, which is a vector. For some reason it was being wrapped by an extra vector. There was a breaking change in EQL version 0.0.10.

https://github.com/edn-query-language/eql/blob/master/CHANGELOG.md#0010

Note this is consistent with what's in the file-upload namespace.

https://github.com/fulcrologic/fulcro/blob/develop/src/main/com/fulcrologic/fulcro/networking/file_upload.cljs#L98