### PR TITLE
Optimize comp/fragment

### DIFF
--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -1214,10 +1214,10 @@
                           [{} args])]
        (vec children))
      :cljs
-     (let [[props children] (if (map? (first args))
-                              [(first args) (rest args)]
-                              [#js {} args])]
-       (apply js/React.createElement js/React.Fragment (clj->js props) (force-children children)))))
+     (let [[props & children] args]
+       (if (map? props)
+         (js/React.createElement js/React.Fragment (clj->js props) (force-children children))
+         (js/React.createElement js/React.Fragment #js {} (force-children args))))))
 
 #?(:clj
    (defmacro with-parent-context


### PR DESCRIPTION
1. The apply seems extraneous

2. Avoid calling clj->js when no props are given, seems to save ~.2us for me.

3. The & binding form is faster:

cljs.user> (simple-benchmark [seq (range 50)] (let [[x y] [(first seq) (rest seq)]]) 1000000)
[seq (range 50)], (let [[x y] [(first seq) (rest seq)]]), 1000000 runs, 116 msecs
cljs.user> (simple-benchmark [seq (range 50)] (let [[x y] [(first seq) (rest seq)]]) 1000000)
[seq (range 50)], (let [[x y] [(first seq) (rest seq)]]), 1000000 runs, 117 msecs
cljs.user> (simple-benchmark [seq (range 50)] (let [[x y] [(first seq) (rest seq)]]) 1000000)
[seq (range 50)], (let [[x y] [(first seq) (rest seq)]]), 1000000 runs, 122 msecs

cljs.user> (simple-benchmark [seq (range 50)] (let [[x & y] seq]) 1000000)
[seq (range 50)], (let [[x & y] seq]), 1000000 runs, 59 msecs
cljs.user> (simple-benchmark [seq (range 50)] (let [[x & y] seq]) 1000000)
[seq (range 50)], (let [[x & y] seq]), 1000000 runs, 52 msecs
cljs.user> (simple-benchmark [seq (range 50)] (let [[x & y] seq]) 1000000)
[seq (range 50)], (let [[x & y] seq]), 1000000 runs, 54 msecs
