### PR TITLE
Fix for element picker on React 17

### DIFF
--- a/src/main/com/fulcrologic/fulcro/inspect/element_picker.cljc
+++ b/src/main/com/fulcrologic/fulcro/inspect/element_picker.cljc
@@ -65,8 +65,9 @@
 (defn react-raw-instance [node]
   #?(:cljs
      (if-let [instance-key (->> (gobj/getKeys node)
-                             (filter #(str/starts-with? % "__reactInternalInstance$"))
-                             (first))]
+                                (filter #(or (str/starts-with? % "__reactInternalInstance$")
+                                             (str/starts-with? % "__reactFiber$")))
+                                (first))]
        (gobj/get node instance-key))))
 
 (defn react-instance [node]


### PR DESCRIPTION
Fulcro Inspect's element picker wasn't working with a clean install of the latest fulcro-template. Neither with the chrome extension nor with the electron inspector app.

After investigating, I found the problem to be that react 17 changed the components internal instance property.