### PR TITLE
defrouter: clarify limitations of default target

### DIFF
--- a/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc
+++ b/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc
@@ -839,7 +839,7 @@
      The options are:
 
      `:router-targets` - (REQUIRED) A *vector* of ui components that are router targets. The first one is considered the \"default\"
-     (purely for the purpose if initial state; you always need to explicitly route to a particular target).
+     (purely for the purpose of initial state; you always need to explicitly route to a particular target).
      Other defsc options - (LIMITED) You may not specify query/initial-state/protocols/ident, but you can define things like react
      lifecycle methods. See defsc.
      `:always-render-body?` - (OPTIONAL) When true this router expects that you will supply a render body, and

--- a/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc
+++ b/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc
@@ -838,7 +838,8 @@
 
      The options are:
 
-     `:router-targets` - (REQUIRED) A *vector* of ui components that are router targets. The first one is considered the \"default\".
+     `:router-targets` - (REQUIRED) A *vector* of ui components that are router targets. The first one is considered the \"default\"
+     (purely for the purpose if initial state; you always need to explicitly route to a particular target).
      Other defsc options - (LIMITED) You may not specify query/initial-state/protocols/ident, but you can define things like react
      lifecycle methods. See defsc.
      `:always-render-body?` - (OPTIONAL) When true this router expects that you will supply a render body, and


### PR DESCRIPTION
I originally believed that relying on the router to display the default target is the same as routing to it explicitly.  https://book.fulcrologic.com/#_partial_routes now explains it isn't but I think it is worth repeating it in the docstring.