### PR TITLE
Emit :style/indent declarations

### DIFF
--- a/src/main/com/fulcrologic/fulcro/dom.clj
+++ b/src/main/com/fulcrologic/fulcro/dom.clj
@@ -178,6 +178,7 @@
 
 (defn gen-dom-macro [emitter name]
   `(defmacro ~name ~(cdom/gen-docstring name true)
+     {:style/indent :defn}
      [& ~'args]
      (let [tag# ~(str name)]
        (try


### PR DESCRIPTION
Hello Tony,

this PR adds :style/indent metadata according to Cider's Indentation
Specification [1] onto the symbols of Fulcro's DOM helpers.

This causes `dom/div` and friends to be indented like a special form
by tools that follow Cider's Indentation Specification.

Before:

```
(dom/form :.bs-signin-form
          {:className "bs-signin-form"}
          (dom/div :.bs-signin-form-login-field
                     (text-field/signin-login))
          (dom/div :.bs-signin-form-password-field
                     (text-field/signin-password))
          (dom/div
           (button/signin)))
```

After:

```
(dom/form :.bs-signin-form
  {:className "bs-signin-form"}
  (dom/div :.bs-signin-form-login-field
    (text-field/signin-login))
  (dom/div :.bs-signin-form-password-field
    (text-field/signin-password))
  (dom/div
    (button/signin)))
```

If this style of formatting is prettier and should be the default for
all Fulcro users is of course a matter of taste. :)

If you prefer the current default behaviour, feel free to ignore this
PR. Then I bite the bullet and put all of [2] to my Emacs config ;)

Thanks r0man.

[1] https://docs.cider.mx/cider/indent_spec.html
[2] https://gist.github.com/cjsauer/407a02529af6871bada5bdb6515ff8ac