### PR TITLE
Issue #443: fixed comp/get-query for ':with-hooks? true' in CLJ

### DIFF
--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -1545,7 +1545,7 @@
                                               hooks? (assoc :componentName fqkw)
                                               render-form (assoc :render render-form))]
        (cond
-         hooks?
+         (and (cljs? env) hooks?)
          `(do
             (defonce ~sym
               (fn [js-props#]

--- a/src/test/com/fulcrologic/fulcro/components_spec.cljc
+++ b/src/test/com/fulcrologic/fulcro/components_spec.cljc
@@ -14,6 +14,14 @@
    :extra-data    42}
   (dom/div "TODO"))
 
+(defsc AWithHooks [this props]
+  {:ident         :person/id
+   :query         [:person/id :person/name]
+   :initial-state {:person/id 1 :person/name "Tony"}
+   :extra-data    42
+   :use-hooks?    true}
+  (dom/div "TODO"))
+
 (defsc B [this props]
   {:ident         :person/id
    :query         [:person/id :person/name]
@@ -39,6 +47,7 @@
       (comp/get-ident A {:person/id 4}) => [:person/id 4]
       "Can be used to obtain the query"
       (comp/get-query A) => [:person/id :person/name]
+      (comp/get-query AWithHooks) => [:person/id :person/name]
       "Initial state"
       (comp/get-initial-state A) => {:person/name "Tony" :person/id 1}
       (comp/get-initial-state B {:id 22}) => {:person/name "Tony" :person/id 22}


### PR DESCRIPTION
The problem was in CLJ component class not having `comp/component-options`. Treating hooks components as a regular React class in CLJ fixes the issue.