### PR TITLE
 Hooks: shared props fix

### DIFF
--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -1421,7 +1421,7 @@
             (fn []
               (binding [*app*    (or *app* (isoget-in ~thissym ["props" "fulcro$app"]))
                         *depth*  (inc (or *depth* (isoget-in ~thissym ["props" "fulcro$depth"])))
-                        *shared* (shared *app*)
+                        *shared* (shared (or *app* (isoget-in ~thissym ["props" "fulcro$app"])))
                         *parent* ~thissym]
                 (let [~@computed-bindings
                       ~@extended-bindings]


### PR DESCRIPTION
Shared props are incorrectly bound to dynamic var in hooks render fn, which leads to issues with e.g. i18n.