### PR TITLE
[WIP] propagate shared props to mutation action handlers

### DIFF
--- a/src/main/com/fulcrologic/fulcro/mutations.cljc
+++ b/src/main/com/fulcrologic/fulcro/mutations.cljc
@@ -436,10 +436,13 @@
                                     (let [action? (str/ends-with? (str handler-name) "action")]
                                       (into acc
                                         (if action?
-                                          [(keyword (name handler-name)) `(fn ~handler-name ~handler-args
-                                                                            (binding [comp/*after-render* true]
-                                                                              ~@handler-body)
-                                                                            nil)]
+                                          [(keyword (name handler-name)) `(fn ~handler-name [env#]
+                                                                            ((fn ~handler-name ~handler-args
+                                                                               (binding [comp/*after-render* true
+                                                                                         comp/*shared*       (-> env# :app comp/shared)]
+                                                                                 ~@handler-body)
+                                                                               nil)
+                                                                             env#))]
                                           [(keyword (name handler-name)) `(fn ~handler-name ~handler-args ~@handler-body)]))))
                             []
                             sections)


### PR DESCRIPTION
i18n doesn't work in mutations because bindings aren't propagated. Tests which check the defmutation macro output do NOT pass: it's somewhat tricky to make them work with gensym, and anyway would like to know what you think about the problem and solution in general.