### PR TITLE
:replace: clarify that for vectors we need index

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/data_targeting.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/data_targeting.cljc
@@ -69,7 +69,7 @@
   - prepend: A vector (path) to a list in your app state where this new object's ident should be prepended. Will not place
   the ident if that ident is already in the list.
   - replace: A vector (path) to a specific location in app-state where this object's ident should be placed. Can target a to-one or to-many.
-   If the target is a vector element then that element must already exist in the vector.
+   If the target is a vector element index then that element must already exist in the vector.
 
   NOTE: `ident` does not have to be an ident if you want to place denormalized data.  It can really be anything.
 


### PR DESCRIPTION
It was not clear to me what a "vector element" was. I thought perhaps it is an ident - since we have a vector of idents - and was confused at what sense that had. After reading the code I saw it actually needs to be an index and suddenly it made sense. For future readers this change will hopefully make it clear straight away.