### PR TITLE
annotating dom where possible with data-fulcro-source html attribute to show namespace and line number

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -2,12 +2,13 @@
  :nrepl    {:port 9000}
  :dev-http {9001 "resources/public"}
  :jvm-opts ["-Xmx2G"]
- :builds   {:workspaces {:target     nubank.workspaces.shadow-cljs.target
-                         :ns-regexp  "-cards$"
-                         :output-dir "resources/public/js/workspaces"
-                         :asset-path "/js/workspaces"
-                         :preloads   [com.fulcrologic.fulcro.inspect.websocket-preload
-                                      com.fulcrologic.fulcro.inspect.dom-picker-preload]}
+ :builds   {:workspaces {:target           nubank.workspaces.shadow-cljs.target
+                         :ns-regexp        "-cards$"
+                         :output-dir       "resources/public/js/workspaces"
+                         :asset-path       "/js/workspaces"
+                         :compiler-options {:external-config {:fulcro {:html-source-annotations? true}}}
+                         :preloads         [com.fulcrologic.fulcro.inspect.websocket-preload
+                                            com.fulcrologic.fulcro.inspect.dom-picker-preload]}
 
             :todomvc    {:target     :browser
                          :output-dir "resources/public/js/todomvc"

--- a/src/main/com/fulcrologic/fulcro/dom.clj
+++ b/src/main/com/fulcrologic/fulcro/dom.clj
@@ -29,7 +29,7 @@
     (clojure.lang ExceptionInfo)))
 
 (defn emit-fulcro-source-annotations? []
-  (not (false? (:html-source-annotations? (comp/current-config)))))
+  (true? (:html-source-annotations? (comp/current-config))))
 
 (defn wrap-inputs? [] (not (false? (:wrap-inputs? (comp/current-config)))))
 

--- a/src/main/com/fulcrologic/fulcro/dom.clj
+++ b/src/main/com/fulcrologic/fulcro/dom.clj
@@ -78,10 +78,12 @@
           source-attrs {:data-fulcro-source (str NS ":" line)}]
       (if-not NS attrs-expr
         (case attrs-type
-          :nil source-attrs
+          :nil         source-attrs
+          :js-object   attrs-expr
+          :map         (merge attrs-expr source-attrs)
           :runtime-map `(merge ~source-attrs ~attrs-expr)
-          :map (merge attrs-expr source-attrs)
-          attrs-expr)))))
+          `(let [a# ~attrs-expr]
+             (cond->> a# (map? a#) (merge ~source-attrs))))))))
 
 (defn emit-tag
   "PRIVATE.  DO NOT USE.

--- a/src/main/com/fulcrologic/fulcro/dom.clj
+++ b/src/main/com/fulcrologic/fulcro/dom.clj
@@ -28,6 +28,9 @@
     (cljs.tagged_literals JSValue)
     (clojure.lang ExceptionInfo)))
 
+(defn emit-fulcro-source-annotations? []
+  (not (false? (:html-source-annotations? (comp/current-config)))))
+
 (defn wrap-inputs? [] (not (false? (:wrap-inputs? (comp/current-config)))))
 
 (defn- map-of-literals? [v]
@@ -66,11 +69,25 @@
                                     :else [k v])))
               m)))
 
+(defn annotate-with-source-attributes [env form attrs-type attrs-expr]
+  (if-not (emit-fulcro-source-annotations?) attrs-expr
+    (let [NS   (if (comp/cljs? env)
+                 (some-> env :ns :name str)
+                 (name (ns-name *ns*)))
+          line (or (some-> form clojure.core/meta :line) "?")
+          source-attrs {:data-fulcro-source (str NS ":" line)}]
+      (if-not NS attrs-expr
+        (case attrs-type
+          :nil source-attrs
+          :runtime-map `(merge ~source-attrs ~attrs-expr)
+          :map (merge attrs-expr source-attrs)
+          attrs-expr)))))
+
 (defn emit-tag
   "PRIVATE.  DO NOT USE.
 
-  Helper function for generating CLJS DOM macros. is public for code gen problems."
-  [str-tag-name args]
+   Helper function for generating CLJS DOM macros. is public for code gen problems."
+  [str-tag-name args & [env form]]
   (let [conformed-args      (util/conform! ::dom-macro-args args)
         {attrs    :attrs
          children :children
@@ -82,7 +99,8 @@
                                       c
                                       `(comp/force-children ~c))) children)
         attrs-type          (or (first attrs) :nil)         ; attrs omitted == nil
-        attrs-value         (or (second attrs) {})
+        attrs-value         (annotate-with-source-attributes env form
+                              attrs-type (or (second attrs) {}))
         create-element      (case str-tag-name
                               "input" 'com.fulcrologic.fulcro.dom/macro-create-wrapped-form-element
                               "textarea" 'com.fulcrologic.fulcro.dom/macro-create-wrapped-form-element
@@ -113,8 +131,13 @@
          ~str-tag-name ~(into [attrs-value] raw-children) ~css)
 
       :nil
-      `(~create-element
-         ~(JSValue. (into [str-tag-name (JSValue. css-props)] children)))
+      (if (seq attrs-value)
+        `(~create-element ~(JSValue. (into [str-tag-name (-> attrs-value
+                                                           (cdom/add-kwprops-to-props css)
+                                                           (clj-map->js-object))]
+                                       children)))
+        `(~create-element
+           ~(JSValue. (into [str-tag-name (JSValue. css-props)] children))))
 
       ;; pure children
       `(com.fulcrologic.fulcro.dom/macro-create-element
@@ -122,7 +145,7 @@
 
 (defn emit-tag-unwrapped
   "PRIVATE.  DO NOT USE. Same as emit-tag, but does no wrap inputs."
-  [str-tag-name args]
+  [str-tag-name args & [env form]]
   (let [conformed-args         (util/conform! ::dom-macro-args args)
         {attrs    :attrs
          children :children
@@ -134,7 +157,8 @@
                                          c
                                          `(comp/force-children ~c))) children)
         attrs-type             (or (first attrs) :nil)      ; attrs omitted == nil
-        attrs-value            (or (second attrs) {})
+        attrs-value            (annotate-with-source-attributes env form
+                                 attrs-type (or (second attrs) {}))
         raw-create-element     'com.fulcrologic.fulcro.dom/macro-create-element*
         runtime-create-element 'com.fulcrologic.fulcro.dom/macro-create-unwrapped-element
         classes-expression?    (and (= attrs-type :map) (contains? attrs-value :classes))
@@ -160,8 +184,13 @@
          ~str-tag-name ~(into [attrs-value] raw-children) ~css)
 
       :nil
-      `(~raw-create-element
-         ~(JSValue. (into [str-tag-name (JSValue. css-props)] children)))
+      (if (seq attrs-value)
+        `(~raw-create-element ~(JSValue. (into [str-tag-name (-> attrs-value
+                                                               (cdom/add-kwprops-to-props css)
+                                                               (clj-map->js-object))]
+                                           children)))
+        `(~raw-create-element
+           ~(JSValue. (into [str-tag-name (JSValue. css-props)] children))))
 
       ;; pure children
       `(~runtime-create-element
@@ -182,7 +211,7 @@
      [& ~'args]
      (let [tag# ~(str name)]
        (try
-         (~emitter tag# ~'args)
+         (~emitter tag# ~'args ~'&env ~'&form)
          (catch ExceptionInfo e#
            (throw (ex-info (syntax-error ~'&form e#) (ex-data e#))))))))
 

--- a/src/workspaces/com/fulcrologic/fulcro/cards/source_annotation_cards.cljs
+++ b/src/workspaces/com/fulcrologic/fulcro/cards/source_annotation_cards.cljs
@@ -1,0 +1,33 @@
+(ns com.fulcrologic.fulcro.cards.source-annotation-cards
+  (:require
+    [nubank.workspaces.card-types.fulcro3 :as ct.fulcro]
+    [nubank.workspaces.core :as ws]
+    [com.fulcrologic.fulcro.components :as comp :refer [defsc]]
+    [com.fulcrologic.fulcro.dom :as dom]
+    [taoensso.timbre :as log]))
+
+(defsc Thing [this {:thing/keys [id] :as props}]
+  {:query         [:thing/id]
+   :ident         :thing/id
+   :initial-state {:thing/id 1}}
+  (let [m {}]
+    (dom/div
+      (dom/p "nil")
+      (dom/p :#paragraph "with css")
+      (dom/div {} "map")
+      (dom/div {:data-id id} "runtime-map")
+      (dom/div m "symbol")
+      (dom/div (merge m {}) "expression")
+      (dom/div #js {} "js-object")
+      (dom/br)
+      (dom/div (dom/div "one"))
+      (dom/div {} (dom/div "two"))
+      (dom/div :.foo "three")
+      (dom/div :.foo (dom/div "four"))
+      (dom/div :.foo {} (dom/div "five"))
+      )))
+
+(ws/defcard thing-card
+  (ct.fulcro/fulcro-card
+    {::ct.fulcro/wrap-root? true
+     ::ct.fulcro/root       Thing}))

--- a/src/workspaces/com/fulcrologic/fulcro/cards/source_annotation_cards.cljs
+++ b/src/workspaces/com/fulcrologic/fulcro/cards/source_annotation_cards.cljs
@@ -3,10 +3,9 @@
     [nubank.workspaces.card-types.fulcro3 :as ct.fulcro]
     [nubank.workspaces.core :as ws]
     [com.fulcrologic.fulcro.components :as comp :refer [defsc]]
-    [com.fulcrologic.fulcro.dom :as dom]
-    [taoensso.timbre :as log]))
+    [com.fulcrologic.fulcro.dom :as dom]))
 
-(defsc Thing [this {:thing/keys [id] :as props}]
+(defsc SourceAnnotationDemo [this {:thing/keys [id] :as props}]
   {:query         [:thing/id]
    :ident         :thing/id
    :initial-state {:thing/id 1}}
@@ -27,7 +26,7 @@
       (dom/div :.foo {} (dom/div "five"))
       )))
 
-(ws/defcard thing-card
+(ws/defcard source-annotation-demo-card
   (ct.fulcro/fulcro-card
     {::ct.fulcro/wrap-root? true
-     ::ct.fulcro/root       Thing}))
+     ::ct.fulcro/root       SourceAnnotationDemo}))

--- a/src/workspaces/com/fulcrologic/fulcro/cards/source_annotation_cards.cljs
+++ b/src/workspaces/com/fulcrologic/fulcro/cards/source_annotation_cards.cljs
@@ -9,7 +9,8 @@
   {:query         [:thing/id]
    :ident         :thing/id
    :initial-state {:thing/id 1}}
-  (let [m {}]
+  (let [m {}
+        j #js {}]
     (dom/div
       (dom/p "nil")
       (dom/p :#paragraph "with css")
@@ -18,8 +19,9 @@
       (dom/div m "symbol")
       (dom/div (merge m {}) "expression")
       (dom/div #js {} "js-object")
+      (dom/div j "sym -> js-object")
       (dom/br)
-      (dom/div (dom/div "one"))
+      (dom/div (dom/div "one") (dom/div "one+"))
       (dom/div {} (dom/div "two"))
       (dom/div :.foo "three")
       (dom/div :.foo (dom/div "four"))


### PR DESCRIPTION
Got it mostly working, but expressions/symbols/js-objects are too tricky for not a lot of gain...
Also I think dom macro spec puts stuff under attrs as an expression, instead of realizing there is no attrs map.
See `src/workspaces/com/fulcrologic/fulcro/cards/source_annotation_cards.cljs`