### PR TITLE
Log error when props are [], not {}

### DIFF
--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -870,8 +870,10 @@
                   (when (or (nil? props) (not (gobj/containsKey props "fulcro$value")))
                     (log/error "Props middleware seems to have the corrupted props for " (component-name class)))
 
-                  (when (sequential? (gobj/get props "fulcro$value"))
-                    (log/error "Props passed to" (component-name class) "are a sequence instead of a map. Perhaps you meant to `map` it over the props?")))))
+                  (when-not (map? (gobj/get props "fulcro$value"))
+                    (log/error "Props passed to" (component-name class) "are of the type"
+                               (type (gobj/get props "fulcro$value"))
+                               "instead of a map. Perhaps you meant to `map` the component over the props?")))))
            (create-element class props children)))
        {:class     class
         :queryid   qid

--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -868,7 +868,10 @@
                     (log/warn "String ref on " (component-name class) " should be a function."))
 
                   (when (or (nil? props) (not (gobj/containsKey props "fulcro$value")))
-                    (log/error "Props middleware seems to have the corrupted props for " (component-name class))))))
+                    (log/error "Props middleware seems to have the corrupted props for " (component-name class)))
+
+                  (when (sequential? (gobj/get props "fulcro$value"))
+                    (log/error "Props passed to" (component-name class) "are a sequence instead of a map. Perhaps you meant to `map` it over the props?")))))
            (create-element class props children)))
        {:class     class
         :queryid   qid


### PR DESCRIPTION
so that the programmer is notified when she forgot to map over a sequence (i.e. she called `(ui-person all-people)` instead of `(map ui-person all-people)`).

I think error is more suitable than a warning because props should always be a map and the target component thus will nont work.