### PR TITLE
Do not warn that props != map if nil

### DIFF
--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -870,7 +870,7 @@
                   (when (or (nil? props) (not (gobj/containsKey props "fulcro$value")))
                     (log/error "Props middleware seems to have the corrupted props for " (component-name class)))
 
-                  (when-not (map? (gobj/get props "fulcro$value"))
+                  (when-not ((fnil map? {}) (gobj/get props "fulcro$value"))
                     (log/error "Props passed to" (component-name class) "are of the type"
                                (type (gobj/get props "fulcro$value"))
                                "instead of a map. Perhaps you meant to `map` the component over the props?")))))


### PR DESCRIPTION
because there already is a better warning when props are nil