### PR TITLE
Check query is valid at dev runtime

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/do_not_use.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/do_not_use.cljc
@@ -156,11 +156,11 @@
   (though the Spec it uses might be both more strinct / more lax than the code
   so do not take it absolutely.
   "
-  [query]
+  [query component-name-fn]
   (when (and #?(:clj true :cljs goog.DEBUG)
              query
              (false? (s/valid? ::eql/query query)))
     (log/error (str "The composed root query is not valid EQL. The app may crash. See `(comp/get-query "
-                    (some-> query meta :component comp/component-name) ")`")
+                    (some-> query meta :component component-name-fn) ")`")
                query))
   query)

--- a/src/main/com/fulcrologic/fulcro/algorithms/do_not_use.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/do_not_use.cljc
@@ -150,3 +150,17 @@
     (if (vector? <>)
       <>
       [<>])))
+
+(defn- check-query-valid
+  "Runtime check that the (typically root) query looks valid
+  (though the Spec it uses might be both more strinct / more lax than the code
+  so do not take it absolutely.
+  "
+  [query]
+  (when (and #?(:clj true :cljs goog.DEBUG)
+             query
+             (false? (s/valid? ::eql/query query)))
+    (log/error (str "The composed root query is not valid EQL. The app may crash. See `(comp/get-query "
+                    (some-> query meta :component comp/component-name) ")`")
+               query))
+  query)

--- a/src/main/com/fulcrologic/fulcro/application.cljc
+++ b/src/main/com/fulcrologic/fulcro/application.cljc
@@ -189,7 +189,7 @@
   [app root]
   (let [initial-db   (-> app ::state-atom deref)
         root-query   (-> (comp/get-query root initial-db)
-                         util/check-query-valid)
+                         (util/check-query-valid comp/component-name))
         initial-tree (comp/get-initial-state root)
         db-from-ui   (if root-query
                        (-> (fnorm/tree->db root-query initial-tree true (merge/pre-merge-transform initial-tree))
@@ -395,7 +395,7 @@
                                        ::root-factory root-factory
                                        ::root-class root)
                                      (update-shared! app)
-                                     (util/check-query-valid (comp/get-query root))
+                                     (util/check-query-valid (comp/get-query root) comp/component-name)
                                      (indexing/index-root! app) ; this may fail if query invalid
                                      (render! app {:force-root? true
                                                    :hydrate?    hydrate?})))))]

--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -1091,7 +1091,7 @@
                      (string? class-or-factory) class-or-factory
                      (some-> class-or-factory meta (contains? :queryid)) (some-> class-or-factory meta :queryid)
                      :otherwise (query-id class-or-factory nil))]
-    (util/check-query-valid (get-query class-or-factory))
+    (util/check-query-valid (get-query class-or-factory) component-name)
     (if (and (string? queryid) (or query params))
       (let [index-root!      (ah/app-algorithm app :index-root!)
             schedule-render! (ah/app-algorithm app :schedule-render!)]

--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -1091,6 +1091,7 @@
                      (string? class-or-factory) class-or-factory
                      (some-> class-or-factory meta (contains? :queryid)) (some-> class-or-factory meta :queryid)
                      :otherwise (query-id class-or-factory nil))]
+    (util/check-query-valid (get-query class-or-factory))
     (if (and (string? queryid) (or query params))
       (let [index-root!      (ah/app-algorithm app :index-root!)
             schedule-render! (ah/app-algorithm app :schedule-render!)]


### PR DESCRIPTION
to provide a better error message than "Invalid expression " from EQL.

TODO:
* also for set-query!
* get the check working upon refresh