### PR TITLE
Update atom? predicate to support reagent atom

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/do_not_use.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/do_not_use.cljc
@@ -19,7 +19,7 @@
             [java.util Base64]
             [java.nio.charset StandardCharsets])))
 
-(defn atom? [a] (instance? Atom a))
+(defn atom? [a] #?(:cljs (satisfies? IAtom a) :clj (instance? Atom a)))
 
 (defn join-entry [expr]
   (let [[k v] (if (seq? expr)


### PR DESCRIPTION
I was experimenting with using a reagent atom for the fulcro db and ran into a spec failure when starting a state machine.
I found that reagent's atom implements the `IAtom` protocol:
https://github.com/reagent-project/reagent/blob/master/src/reagent/ratom.cljs#L128
and after using this for the predicate in cljs the fulcro app boots without errors.