### PR TITLE
Outline some changes for fixing JVM clojure compilation

### DIFF
--- a/src/main/com/fulcrologic/fulcro/alpha/raw_components.cljc
+++ b/src/main/com/fulcrologic/fulcro/alpha/raw_components.cljc
@@ -75,6 +75,7 @@
     (inspect/app-started! app)
     app))
 
+#?(:cljs
 (defn factory
   "A Fulcro component factory for RAW React usage.
 
@@ -111,7 +112,7 @@
               (create-element class props children)))))
       {:class     class
        :queryid   qid
-       :qualifier qualifier})))
+          :qualifier qualifier}))))
 
 (defn- pcs [app component prior-props-tree-or-ident]
   (let [ident           (if (eql/ident? prior-props-tree-or-ident)
@@ -160,7 +161,8 @@
                                               initial-state-params (comp/get-initial-state component initial-state-params)
                                               (comp/has-initial-app-state? component) (comp/get-initial-state component {})
                                               :else {})))
-        [id _] (hooks/use-state (random-uuid))]
+        [id _] (hooks/use-state #?(:clj  (java.util.UUID/randomUUID)
+                                   :cljs (random-uuid)))]
     (hooks/use-lifecycle
       (fn []
         (let [state-map (app/current-state app)

--- a/src/main/com/fulcrologic/fulcro/alpha/raw_components2.cljc
+++ b/src/main/com/fulcrologic/fulcro/alpha/raw_components2.cljc
@@ -78,6 +78,7 @@
     (inspect/app-started! app)
     app))
 
+#?(:cljs
 (defn factory
   "A Fulcro component factory for RAW React usage.
 
@@ -116,7 +117,7 @@
                (create-element class props children))))
          {:class     class
           :queryid   qid
-          :qualifier qualifier}))))
+             :qualifier qualifier})))))
 
 (defn- pcs [app component prior-props-tree-or-ident]
   (let [ident           (if (eql/ident? prior-props-tree-or-ident)

--- a/src/main/com/fulcrologic/fulcro/dom.cljs
+++ b/src/main/com/fulcrologic/fulcro/dom.cljs
@@ -148,6 +148,7 @@
   (let [tag (.-tagName element)]
     (and tag (form-elements? (str/lower-case tag)))))
 
+#?(:cljs
 (defn wrap-form-element [element]
   (let [ctor (fn [props]
                (this-as this
@@ -200,7 +201,7 @@
                   (gobj/set p "inputRef" r)
                   (gobj/remove p "ref")
                   (apply real-factory p children)))
-              (apply real-factory props children))))))))
+                 (apply real-factory props children)))))))))
 
 
 (def wrapped-input "Low-level form input, with no syntactic sugar. Used internally by DOM macros" (wrap-form-element "input"))

--- a/src/main/com/fulcrologic/fulcro/dom/inputs.cljc
+++ b/src/main/com/fulcrologic/fulcro/dom/inputs.cljc
@@ -12,6 +12,7 @@
     [com.fulcrologic.fulcro.components :as comp]
     [com.fulcrologic.fulcro.dom.events :as evt]))
 
+#?(:cljs
 (defn StringBufferedInput
   "Create a new type of input that can be derived from a string. `kw` is a fully-qualified keyword name for the new
   class (which will be used to register it in the component registry), and `model->string` and `string->model` are
@@ -69,13 +70,14 @@
                       onBlur (assoc :onBlur (fn [evt]
                                               (onBlur (-> evt evt/target-value string->model)))))))))))})
     (comp/register-component! kw cls)
-    cls))
+       cls)))
 
 (defn symbol-chars
   "Returns `s` with all non-digits stripped."
   [s]
   (str/replace s #"[\s\t:]" ""))
 
+#?(:cljs
 (def ui-keyword-input
   "A keyword input. Used just like a DOM input, but requires you supply nil or a keyword for `:value`, and
    will send a keyword to `onChange` and `onBlur`. Any other attributes in props are passed directly to the
@@ -83,7 +85,7 @@
   (comp/factory (StringBufferedInput ::KeywordInput {:model->string #(str (some-> % name))
                                                      :string-filter symbol-chars
                                                      :string->model #(when (seq %)
-                                                                       (some-> % keyword))})))
+                                                                          (some-> % keyword))}))))
 (defn to-int
   "Convert a string `s`"
   [s]
@@ -104,6 +106,7 @@
     (str/join
       (filter digits (seq s)))))
 
+#?(:cljs
 (def ui-int-input
   "An integer input. Can be used like `dom/input` but onChange and onBlur handlers will be passed an int instead of
   a raw react event, and you should supply an int for `:value` instead of a string.  You may set the `:type` to text
@@ -111,5 +114,4 @@
   All other attributes passed in props are passed through to the contained `dom/input`."
   (comp/factory (StringBufferedInput ::IntInput {:model->string str
                                                  :string->model to-int
-                                                 :string-filter just-digits})))
-
+                                                    :string-filter just-digits}))))

--- a/src/main/com/fulcrologic/fulcro/rendering/multiple_roots_renderer.cljc
+++ b/src/main/com/fulcrologic/fulcro/rendering/multiple_roots_renderer.cljc
@@ -170,6 +170,7 @@
                     comp/*depth*  d#]
             ~@body)))))
 
+#?(:cljs
 (defn floating-root-react-class
   "Generate a plain React class that can render a Fulcro UIRoot. NOTE: The UIRoot must register/deregister itself
   in the component lifecycle:
@@ -202,7 +203,7 @@
                                                    state-map (some-> fulcro-app :com.fulcrologic.fulcro.application/state-atom deref)
                                                    props     (fdn/db->tree query state-map state-map)]
                                                (ui-root props {:js-props js-props})))))))})))
-    cls))
+       cls)))
 
 (defn floating-root-factory
   "Create a factory that renders a floating root in a normal Fulcro context (body of a Fulcro component). This factory

--- a/src/todomvc/fulcro_todomvc/playground.cljs
+++ b/src/todomvc/fulcro_todomvc/playground.cljs
@@ -255,6 +255,7 @@
       (dom/button {:onClick (fn []
                               (comp/update-state! this update :n inc))} "Click me!"))))
 
+#?(:cljs
 (defn ui-sample [props & children]
   (let [{:keys [::app/middleware]} *reconciler*
         ep-mw       (get middleware :extra-props-middleware)
@@ -262,7 +263,7 @@
                       (this-as this (ep-mw this)))]
     (dom/create-element Sample #js {"fulcro$value"       props
                                     "fulcro$extra_props" extra-props
-                                    "fulcro$reconciler"  *reconciler*})))
+                                       "fulcro$reconciler"  *reconciler*}))))
 
 (defn wrap-my-extra
   ([] (fn [this] {:some-value 1}))


### PR DESCRIPTION
Hi!

Because of an issue reported in Eastwood, I tried to run that linter over this project.

That made me find out that despite that the Fulcro project is coded in .cljc, a few spots can't be successfully compiled over the JVM.

This PR outlines a few possible fixes. I only checked over `main`, not `test` or others.

It's not intended for merging as I'm not a primary user of Fulcro. If you are interested in this improvement you could simply pick it up and improve it as desired.

In case it helps, here is the alias I used for checking valid compilation:

```clj
           :lint/eastwood
           {:extra-deps {jonase/eastwood {:mvn/version "0.4.0"}}
            :jvm-opts   ["-Dclojure.main.report=stderr"]
            ;; feel free to add "src/test" and others:
            :main-opts  ["-m" "eastwood.lint" "{:source-paths,[\"src/main\"]}"]}
```

...a valid compilation will simply return linter faults, and an invalid compilation will throw an exception due to the cljs-only bits.

(another way of checking would be using tools.namespace `refresh`. Or use something akin to `lein check` if that exists for deps.edn?)

Hope it helps!

-V