### PR TITLE
Bad prop type log improvement

### DIFF
--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -875,7 +875,7 @@
 
                   (when-not ((fnil map? {}) (gobj/get props "fulcro$value"))
                     (log/error "Props passed to" (component-name class) "are of the type"
-                      (type (gobj/get props "fulcro$value"))
+                      (type->str (type (gobj/get props "fulcro$value")))
                       "instead of a map. Perhaps you meant to `map` the component over the props?")))))
            (create-element class props children)))
        {:class     class


### PR DESCRIPTION
Make sure we log the name of the cljs data structure type when
it is that (or, as we do now, "function ..." otherwise).

The `type` call just returns a reference to the `.-constructor`
and `type->str` gets the type name from it (at least in dev
mode, likely munged in release). If we just print the `type` as
we do now, it - at least sometimes - gets printed as the body of
the constructor instead of its cljs name. (Notice that the name is
not stored in its `.-name` prop as one might expect.)