### PR TITLE
turn `m/returning`s optional arg into a generic opts map

### DIFF
--- a/src/main/com/fulcrologic/fulcro/mutations.cljc
+++ b/src/main/com/fulcrologic/fulcro/mutations.cljc
@@ -331,11 +331,14 @@
   `env` - The env of the mutation
   `class` - A component class that represents the return type.  You may supply a fully-qualified symbol instead of the
   actual class, and this method will look up the class for you (useful to avoid circular references).
+  `opts` (optional):
+   - `query-params` - Optional parameters to add to the generated query
 
   Returns an update `env`, and is a valid return value from mutation remote sections."
   ([env class]
    (returning env class nil))
-  ([env class query-params]
+  ([env class {:keys [query-params]
+               :as   opts}]
    (let [class (if (or (keyword? class) (symbol? class))
                  (rc/registry-key->class class)
                  class)]

--- a/src/test/com/fulcrologic/fulcro/mutations_spec.cljc
+++ b/src/test/com/fulcrologic/fulcro/mutations_spec.cljc
@@ -23,7 +23,7 @@
                :ast   (-> (eql/query->ast '[(f)])
                         :children
                         first)}
-          {new-ast :ast} (m/returning env (rc/nc [:person/id :person/name]) {:page 2})]
+          {new-ast :ast} (m/returning env (rc/nc [:person/id :person/name]) {:query-params {:page 2}})]
       (assertions
         "sets the query of the parent node"
         (:query new-ast) => '[(:person/id {:page 2}) :person/name]


### PR DESCRIPTION
more work will be required to support `without` due to circular dependencies with public functions. 