### PR TITLE
Raw API: Fix batched notifications, hooks returning nil & more.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/.jekyll-metadata
 .shadow-cljs
 resources/public/workspaces
 !.idea/runConfigurations
+.lsp

--- a/src/main/com/fulcrologic/fulcro/mutations.cljc
+++ b/src/main/com/fulcrologic/fulcro/mutations.cljc
@@ -423,7 +423,7 @@
                                       (into acc
                                         (if action?
                                           [(keyword (name handler-name)) `(fn ~handler-name ~handler-args
-                                                                            (binding [com.fulcrologic.fulcro.components/*after-render* true]
+                                                                                                    (binding [com.fulcrologic.fulcro.raw.components/*after-render* true]
                                                                               ~@handler-body)
                                                                             nil)]
                                           [(keyword (name handler-name)) `(fn ~handler-name ~handler-args ~@handler-body)]))))
@@ -436,7 +436,7 @@
                             `{~(first handlers) ~@(rest handlers)}
                             `{~(first handlers) ~@(rest handlers)
                               :result-action    (fn [~'env]
-                                                  (binding [com.fulcrologic.fulcro.components/*after-render* true]
+                                                                      (binding [com.fulcrologic.fulcro.raw.components/*after-render* true]
                                                     (when-let [~'default-action (ah/app-algorithm (:app ~'env) :default-result-action!)]
                                                       (~'default-action ~'env))))})
            doc            (or doc "")

--- a/src/main/com/fulcrologic/fulcro/raw/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/raw/components.cljc
@@ -797,6 +797,21 @@
            ast-nodes (-> query eql/query->ast :children)]
        (get-subquery-component* component ast-nodes query-path)))))
 
+(defn get-traced-props
+  "Uses `fdn/traced-db->tree` to get the props of the component at `ident`. If `prior-props` are not stale,
+   those are returned instead."
+  [state-map component {:keys [ident prior-props]}]
+  (let [query (get-query component state-map)]
+    (if (fdn/possibly-stale? state-map prior-props)
+      (fdn/traced-db->tree state-map ident query)
+      prior-props)))
+
+(defn has-active-state?
+  "Returns true if there is already data at a component's ident"
+  [state-map ident]
+  (let [current-value (get-in state-map ident)]
+    (and (map? current-value) (seq current-value))))
+
 (comment
   (def Person (entity->component
                 {:person/id        1

--- a/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc
+++ b/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc
@@ -15,6 +15,7 @@
     [com.fulcrologic.guardrails.core :refer [>fdef => ?]]
     [com.fulcrologic.fulcro.ui-state-machines :as uism :refer [defstatemachine]]
     [com.fulcrologic.fulcro.components :as comp]
+   [com.fulcrologic.fulcro.raw.components :as rc]
     [com.fulcrologic.fulcro.application :as app]
     [com.fulcrologic.fulcro.mutations :refer [defmutation]]
     [edn-query-language.core :as eql]
@@ -686,7 +687,8 @@
                         (uism/trigger! app router-id :route! event-data))
                       ;; make sure any transactions submitted from the completing action wait for a render of the state machine's
                       ;; startup or route effects before running.
-                      (binding [comp/*after-render* true]
+                           ;; TASK: check on after-render
+                           (binding [rc/*after-render* true]
                         (completing-action))))
                  (when (seq remaining-path)
                    (recur (ast-node-for-route target-ast remaining-path) remaining-path)))))


### PR DESCRIPTION
- Changes to `use-root` and `use-component` hooks:
  - The component state is initialised on the first mount of the component, then current-props are initialised and ready to use on the first render
  - An effect hook manages the addition/removal of the render listener
  - use-component:
    - Randomly generates a UUID to use for the render listener so that multiple components can share the same ident
    - Uses the :ident option if provided
- Changes to raw.application
  - In `render!` — use :batch-notifications (not :batch-renders) to match the key provided to the application.
  - In `add-component!` and `add-root!` — Refactor out parts into helper functions which are also used by the hooks. (Two of these are in raw.components)
  - `add-component!` uses the :ident option if provided, and `initialize?` is now true by default
- Replaced references to components/*after-render* with raw.components/*after-render*