### PR TITLE
Parameterise response in handle-api-request

### DIFF
--- a/src/main/com/fulcrologic/fulcro/server/api_middleware.clj
+++ b/src/main/com/fulcrologic/fulcro/server/api_middleware.clj
@@ -63,8 +63,12 @@
   "Given a parser and a query: Runs the parser on the query,
    and generates a standard Fulcro-compatible response, and augment the raw Ring response with
    any augment handlers that were indicated on top-level mutations/queries via
-   `augment-response`."
+   `augment-response`.
+   Optionally, specify the starting response map to be fed to the augment handlers (ie. to
+   include the request `:session`."
   [query query-processor]
+  (handle-api-request query query-processor {})
+  [query query-processor base-resp]
   (generate-response
     (let [parse-result (try
                          (query-processor query)
@@ -73,7 +77,10 @@
                            e))]
       (if (instance? Throwable parse-result)
         {:status 500 :body "Internal server error. Parser threw an exception. See server logs for details."}
-        (merge {:status 200 :body parse-result} (apply-response-augmentations parse-result))))))
+        (merge
+          {:status 200 :body parse-result}
+          base-resp
+          (apply-response-augmentations parse-result))))))
 
 (defn reader
   "Create a transit reader. This reader can handler the tempid type.

--- a/src/main/com/fulcrologic/fulcro/server/api_middleware.clj
+++ b/src/main/com/fulcrologic/fulcro/server/api_middleware.clj
@@ -56,8 +56,10 @@
   `augment-response`. Runs each in turn and accumulates their effects. The result is
   meant to be a Ring response (and is used as such by `handle-api-request`."
   [response]
+  (apply-response-augmentations response {})
+  [response base-resp]
   (->> (keep #(some-> (second %) meta ::augment-response) response)
-    (reduce (fn [response f] (f response)) {})))
+    (reduce (fn [response f] (f response)) base-resp)))
 
 (defn handle-api-request
   "Given a parser and a query: Runs the parser on the query,
@@ -79,8 +81,7 @@
         {:status 500 :body "Internal server error. Parser threw an exception. See server logs for details."}
         (merge
           {:status 200 :body parse-result}
-          base-resp
-          (apply-response-augmentations parse-result))))))
+          (apply-response-augmentations parse-result base-resp))))))
 
 (defn reader
   "Create a transit reader. This reader can handler the tempid type.


### PR DESCRIPTION
Allows you to start building the response from a known non-empty state (eg. with the requests :session), which allows augment-handlers to relax their assumptions about any other handler's changes, and the potential for clashes.

Hi Tony, this is just a sketch - I haven't run the regression tests. Cheers, Alister.