### PR TITLE
Clj kondo config

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["resources/clj-kondo.exports/com.fulcrologic/fulcro"]}

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ docs/.jekyll-metadata
 resources/public/workspaces
 !.idea/runConfigurations
 .lsp
+.clj-kondo/.cache/

--- a/resources/clj-kondo.exports/com.fulcrologic/fulcro/com.fulcrologic/fulcro/clj-kondo-hooks.clj
+++ b/resources/clj-kondo.exports/com.fulcrologic/fulcro/com.fulcrologic/fulcro/clj-kondo-hooks.clj
@@ -1,0 +1,62 @@
+(ns com.fulcrologic.fulcro.clj-kondo-hooks
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn defmutation
+  [{:keys [node]}]
+  (let [args          (rest (:children node))
+        mutation-name (first args)
+        ?docstring    (when (string? (api/sexpr (second args)))
+                        (second args))
+        args          (if ?docstring
+                        (nnext args)
+                        (next args))
+        params        (first args)
+        handlers      (rest args)
+        handler-syms  (map (comp first :children) handlers)
+        bogus-usage   (api/vector-node (vec handler-syms))
+        letfn-node    (api/list-node
+                       (list
+                        (api/token-node 'letfn)
+                        (api/vector-node (vec handlers))
+                        bogus-usage))
+        new-node      (api/list-node
+                       (list
+                        (api/token-node 'defn)
+                        mutation-name
+                        params
+                        letfn-node))]
+    (doseq [handler handlers]
+      (let [hname (some-> handler :children first api/sexpr str)
+            argv  (some-> handler :children second)]
+        (when-not (= 1 (count (api/sexpr argv)))
+          (api/reg-finding! (merge
+                             (meta argv)
+                             {:message (format "defmutation handler '%s' should be a fn of 1 arg" hname)
+                              :type    :clj-kondo.fulcro.defmutation/handler-arity})))))
+    {:node new-node}))
+
+(defn >defn
+  [{:keys [node]}]
+  (let [args       (rest (:children node))
+        fn-name    (first args)
+        ?docstring (when (string? (api/sexpr (second args)))
+                     (second args))
+        args       (if ?docstring
+                     (nnext args)
+                     (next args))
+        argv       (first args)
+        gspec      (second args)
+        body       (nnext args)
+        new-node   (api/list-node
+                    (list*
+                     (api/token-node 'defn)
+                     fn-name
+                     argv
+                     gspec
+                     body))]
+    (when (not= (count (api/sexpr argv))
+                (count (take-while #(not= '=> %) (api/sexpr gspec))))
+      (api/reg-finding! (merge (meta gspec)
+                               {:message "Guardrail spec does not match function signature"
+                                :type    :clj-kondo.fulcro.>defn/signature-mismatch})))
+    {:node new-node}))

--- a/resources/clj-kondo.exports/com.fulcrologic/fulcro/config.edn
+++ b/resources/clj-kondo.exports/com.fulcrologic/fulcro/config.edn
@@ -1,0 +1,13 @@
+{:hooks {:analyze-call {com.fulcrologic.fulcro.mutations/defmutation com.fulcrologic.fulcro.clj-kondo-hooks/defmutation
+                        com.fulcrologic.guardrails.core/>defn com.fulcrologic.fulcro.clj-kondo-hooks/>defn}}
+ :linters {:clj-kondo.fulcro.defmutation/handler-arity {:level :error}
+           :clj-kondo.fulcro.>defn/signature-mismatch {:level :error}}
+ :lint-as {com.fulcrologic.fulcro.components/defsc                  clojure.core/defn
+           com.fulcrologic.fulcro.routing.dynamic-routing/defrouter clojure.core/defn
+           com.fulcrologic.fulcro.ui-state-machines/defstatemachine clojure.core/def
+           com.fulcrologic.guardrails.core/>def                     clojure.core/def
+           com.fulcrologic.guardrails.core/>defn                    clojure.core/defn
+           com.fulcrologic.rad.attributes/defattr                   clojure.core/def
+           com.fulcrologic.rad.report/defsc-report                  clojure.core/defn
+           com.fulcrologic.rad.form/defsc-form                      clojure.core/defn
+           com.fulcrologic.rad.authorization/defauthenticator       clojure.core/def}}


### PR DESCRIPTION
so that Fulcro users can import them with
`clj-kondo --copy-configs ...` - see
https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#exporting-and-importing-configuration

A copy of https://github.com/clj-kondo/config/tree/a4139daf79255cf646e0f1b81d47ccfdc05814ce/resources/clj-kondo.exports/clj-kondo/fulcro
with renamed ns