### PR TITLE
Fix clj-kondo include path

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,1 +1,1 @@
-{:config-paths ["resources/clj-kondo.exports/com.fulcrologic/fulcro"]}
+{:config-paths ["../src/clj-kondo/clj-kondo.exports/com.fulcrologic/fulcro"]}


### PR DESCRIPTION
Before:

```
❯ clj-kondo --lint src/main/com/fulcrologic/fulcro/react/error_boundaries.cljc
...
src/main/com/fulcrologic/fulcro/react/error_boundaries.cljc:16:8: error: Unresolved symbol: BodyContainer
src/main/com/fulcrologic/fulcro/react/error_boundaries.cljc:19:4: error: Unresolved symbol: this
src/main/com/fulcrologic/fulcro/react/error_boundaries.cljc:19:17: error: Unresolved symbol: parent
src/main/com/fulcrologic/fulcro/react/error_boundaries.cljc:19:24: error: Unresolved symbol: render
src/main/com/fulcrologic/fulcro/react/error_boundaries.cljc:26:8: error: Unresolved symbol: ErrorBoundary
src/main/com/fulcrologic/fulcro/react/error_boundaries.cljc:26:28: error: Unresolved symbol: props
linting took 33ms, errors: 6, warnings: 3
```

after:

```
❯ clj-kondo --lint src/main/com/fulcrologic/fulcro/react/error_boundaries.cljc
...
linting took 33ms, errors: 0, warnings: 4
```