### PR TITLE
docs fix: deferred-timeout default seems to be 20ms

### DIFF
--- a/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc
+++ b/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc
@@ -723,7 +723,7 @@
   `{:error-timeout ms :deferred-timeout ms}`.  Anything extra will appear in the `params` of `will-enter`.
 
   The error timeout is how long to wait  (default 5000ms) before showing the error-ui of a route (which must be defined on the
-  router that is having problems).  The deferred-timeout (default 100ms) is how long to wait before showing the loading-ui of
+  router that is having problems).  The deferred-timeout (default 20ms) is how long to wait before showing the loading-ui of
   a deferred router (to prevent flicker).
   "
   ([this new-route]


### PR DESCRIPTION
According to https://github.com/fulcrologic/fulcro/blob/f1ff70f862c46b8dd10e886686271916cdfa590a/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc#L329 and https://github.com/fulcrologic/fulcro/blob/f1ff70f862c46b8dd10e886686271916cdfa590a/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc#L676 the defaults seems to be actually 20ms, not 100ms as the docs claim.