### PR TITLE
Fix and improve `>defn` clj-kondo hook

### DIFF
--- a/src/clj-kondo/clj-kondo.exports/com.fulcrologic/fulcro/com/fulcrologic/fulcro/clj_kondo_hooks.clj
+++ b/src/clj-kondo/clj-kondo.exports/com.fulcrologic/fulcro/com/fulcrologic/fulcro/clj_kondo_hooks.clj
@@ -35,6 +35,9 @@
                               :type    :clj-kondo.fulcro.defmutation/handler-arity})))))
     {:node new-node}))
 
+(def =>? #{'=> :ret})
+(def |? #{'| :st})
+
 (defn >defn
   [{:keys [node]}]
   (let [args       (rest (:children node))
@@ -54,9 +57,39 @@
                      argv
                      gspec
                      body))]
-    (when (not= (count (api/sexpr argv))
-                (count (take-while #(not= '=> %) (api/sexpr gspec))))
+    ;; gspec: [arg-specs* (| arg-preds+)? => ret-spec (| fn-preds+)? (<- generator-fn)?]
+    (if (not= 1 (count (filter =>? (api/sexpr gspec))))
       (api/reg-finding! (merge (meta gspec)
-                               {:message "Guardrail spec does not match function signature"
-                                :type    :clj-kondo.fulcro.>defn/signature-mismatch})))
+                          {:message (str "Gspec requires exactly one `=>` or `:ret`")
+                           :type    :clj-kondo.fulcro.>defn/invalid-gspec}))
+      (let [p (partition-by (comp not =>? api/sexpr) (:children gspec))
+            [arg [=>] [ret-spec & _output]] (if (-> p ffirst api/sexpr =>?)
+                                              (cons [] p) ; arg-specs might be empty
+                                              p)
+            [arg-specs [| & arg-preds]] (split-with (comp not |? api/sexpr) arg)]
+
+        (when-not ret-spec
+          (println =>)
+          (api/reg-finding! (merge (meta =>)
+                              {:message "Missing return spec."
+                               :type    :clj-kondo.fulcro.>defn/invalid-gspec})))
+
+        ;; (| arg-preds+)?
+        (when (and | (empty? arg-preds))
+          (api/reg-finding! (merge (meta |)
+                              {:message "Missing argument predicates after |."
+                               :type    :clj-kondo.fulcro.>defn/invalid-gspec})))
+
+
+        (let [len-argv (count (remove #{'&} (api/sexpr argv))) ; [a & more] => 2 arguments
+              arg-difference (- (count arg-specs) len-argv)]
+          (when (not (zero? arg-difference))
+            (let [too-many-specs? (pos? arg-difference)]
+              (api/reg-finding! (merge
+                                  (meta (if too-many-specs?
+                                          (nth arg-specs (+ len-argv arg-difference -1)) ; first excess spec
+                                          gspec)) ; The gspec is wrong, not the surplus argument.
+                                  {:message (str "Guardrail spec does not match function signature. "
+                                              "Too " (if too-many-specs? "many" "few") " specs.")
+                                   :type    :clj-kondo.fulcro.>defn/invalid-gspec})))))))
     {:node new-node}))

--- a/src/clj-kondo/clj-kondo.exports/com.fulcrologic/fulcro/config.edn
+++ b/src/clj-kondo/clj-kondo.exports/com.fulcrologic/fulcro/config.edn
@@ -1,7 +1,7 @@
 {:hooks {:analyze-call {com.fulcrologic.fulcro.mutations/defmutation com.fulcrologic.fulcro.clj-kondo-hooks/defmutation
                         com.fulcrologic.guardrails.core/>defn com.fulcrologic.fulcro.clj-kondo-hooks/>defn}}
  :linters {:clj-kondo.fulcro.defmutation/handler-arity {:level :error}
-           :clj-kondo.fulcro.>defn/signature-mismatch {:level :error}}
+           :clj-kondo.fulcro.>defn/invalid-gspec {:level :error}}
  :lint-as {com.fulcrologic.fulcro.components/defsc                  clojure.core/defn
            com.fulcrologic.fulcro.routing.dynamic-routing/defrouter clojure.core/defn
            com.fulcrologic.fulcro.ui-state-machines/defstatemachine clojure.core/def


### PR DESCRIPTION
The current clj-kondo hook for `>defn` produces a false positive when using argument predicates ("such that").

This would fail because the current implementation counts everything before `=>`:
```clojure
(>defn my-fn [x]
  [::x | #(pos? x) => any?] 
  x)
```

-------------

I took the chance and added some more checks to the gspec validation.

gspec reference:
`[arg-specs* (| arg-preds+)? => ret-spec (| fn-preds+)? (<- generator-fn)?]`

What errors are caught?
- Missing `=>` 
- Missing `ret-spec`
- `|` present but no `arg-preds`
- number of `arg-specs` is not equal to number of arguments

@holyjak Maybe you want to review this as well?