### PR TITLE
Rm unnecessary, wrongly typed arg to ana/error

### DIFF
--- a/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc
+++ b/src/main/com/fulcrologic/fulcro/routing/dynamic_routing.cljc
@@ -737,7 +737,7 @@
 
 #?(:clj
    (defn compile-error [env form message]
-     (throw (ana/error (merge env (some-> form meta)) message {}))))
+     (throw (ana/error (merge env (some-> form meta)) message))))
 
 #?(:clj (s/def ::router-targets (s/coll-of symbol? :type vector?)))
 #?(:clj (s/def ::always-render-body? boolean?))


### PR DESCRIPTION
This causes

> ClassCastException: class clojure.lang.PersistentArrayMap cannot be cast to class java.lang.Throwable

instead of the expected

> Encountered error when macroexpanding com.fulcrologic.fulcro.routing.dynamic-routing/defrouter.
defrouter options are invalid: {:router-targetsXXX [Main]}

The 3rd argument to ana/error should be the cause, i.e. a Throwable.