### PR TITLE
Fix targeting/replace-at for [] target

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/data_targeting.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/data_targeting.cljc
@@ -139,6 +139,7 @@
                      (cond
                        (prepend-target? target) (update-in state target (fn [v] (vec (concat item-to-place v))))
                        (append-target? target) (update-in state target (fn [v] (vec (concat v item-to-place))))
+                       (replacement-target? target) (assoc-in state target item-to-place)
                        :else state)
                      (assoc-in state target item-to-place)))
 


### PR DESCRIPTION
If the target property's value was a vector then replace-at did nothing,
instead of replacing the whole value.