### PR TITLE
In use-component, clear prior-props when current-ident changes

### DIFF
--- a/src/main/com/fulcrologic/fulcro/react/hooks.cljc
+++ b/src/main/com/fulcrologic/fulcro/react/hooks.cljc
@@ -306,7 +306,9 @@
                         (when-not (identical? (.-current prior-props-ref) props)
                           (set! (.-current prior-props-ref) props)
                           (set-props! props)))))
-                  (fn use-tree-remove-render-listener* [] (rapp/remove-render-listener! app listener-id))))
+                  (fn use-tree-remove-render-listener* []
+                    (rapp/remove-render-listener! app listener-id)
+                    (set! (.-current prior-props-ref) nil))))
          [(hash current-ident)])
        current-props)))
 


### PR DESCRIPTION
Allows fdn/possibly-stale? to become true.

Without this change, we have seen current-ident changing, prior-props staying the same, and the component therefore never updates.