### PR TITLE
Use (-> app config :load-mutation) in df/load-field! like df/load!

### DIFF
--- a/src/main/com/fulcrologic/fulcro/data_fetch.cljc
+++ b/src/main/com/fulcrologic/fulcro/data_fetch.cljc
@@ -306,6 +306,8 @@
   [component field-or-fields options]
   (let [app          (rc/any->app component)
         {:keys [parallel update-query]} options
+        {:keys [load-mutation]} (-> app :com.fulcrologic.fulcro.application/config)
+        load-sym     (or load-mutation `internal-load!)
         ident        (rc/get-ident component)
         update-query (fn [q]
                        (cond-> (eql/focus-subquery q (if (vector? field-or-fields)
@@ -316,7 +318,7 @@
                                                          :update-query update-query
                                                          :source-key (rc/get-ident component)))
         abort-id     (:abort-id params)]
-    (rc/transact! app [(list `internal-load! params)]
+    (rc/transact! app [(list load-sym params)]
       (cond-> {}
         (boolean? parallel) (assoc :parallel? parallel)
         abort-id (assoc ::txn/abort-id abort-id)))))


### PR DESCRIPTION
Hello Toni!
I tweaked `finish-load!` to trigger persisting data to IndexedDB.
So I provide a copy of `internal-load!`, which uses the tweaked `finish-load!` as `:load-mutation` to my app.
This works like a charm with `load!` but gets ignored by `load-field!`.
This patches `load-field!` to behave like `load!` in respect to honouring the `:load-mutation` in app/config.
This might be a breaking change if someone relies on `load-field!` ignoring `:load-mutation`.
Thank you for your work, fulcro and your training and education!