### PR TITLE
Add :component-will-unmount-middleware option to fulcro-app

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/lookup.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/lookup.cljc
@@ -30,6 +30,7 @@
   - `:index-component!` - The algorithm that adds a component to indexes when it mounts.
   - `:drop-component!` - The algorithm that removes a component from indexes when it unmounts.
   - `:props-middleware` - Middleware that can modify `props` for all components.
+  - `:component-will-unmount-middleware` - Middleware that wraps `componentWillUnmount` methods of `defsc` components.
   - `:render-middleware` - Middlware that wraps all `render` methods of `defsc` components.
 
   Returns nil if the algorithm is currently undefined.

--- a/src/main/com/fulcrologic/fulcro/application.cljc
+++ b/src/main/com/fulcrologic/fulcro/application.cljc
@@ -191,6 +191,11 @@
      render, and *must* call (and return the result of) `real-render`.  This can be used to wrap the real render
      function in order to do things like measure performance, set dynamic vars, or augment the UI in arbitrary ways.
      `this` is the component being rendered.
+   * `:component-will-unmount-middleware` - A `(fn [this real-comp-will-unmount])`. If supplied it will be called whenever a Fulcro component
+     will unmount, and *must* call `real-comp-will-unmount`. This can be used to wrap the real `componentWillUnmount`
+     function in order to do things like clean up resources you may have added to the component in `render-middleware`,
+     set dynamic vars, or any other manipulation of the component instance before it unmounts.
+     `this` is the component being unmounted.
    * `:remote-error?` - A `(fn [result] boolean)`. It can examine the network result and should only return
      true when the result is an error. The `result` will contain both a `:body` and `:status-code` when using
      the normal remotes.  The default version of this returns true if the status code isn't 200.
@@ -215,6 +220,7 @@
      `:submit-transaction!`, since the two are related."
   ([] (fulcro-app {}))
   ([{:keys [props-middleware
+            component-will-unmount-middleware
             global-eql-transform
             global-error-action
             default-result-action!

--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -331,10 +331,12 @@
      #?(:cljs
         (this-as this
           (let [{:keys [componentWillUnmount]} (component-options this)
-                app             (any->app this)
-                drop-component! (ah/app-algorithm app :drop-component!)]
-            (when componentWillUnmount
-              (componentWillUnmount this))
+                app                     (any->app this)
+                will-unmount-middleware (ah/app-algorithm app :component-will-unmount-middleware)
+                drop-component!         (ah/app-algorithm app :drop-component!)]
+            (if will-unmount-middleware
+              (will-unmount-middleware this (fn [] (when componentWillUnmount (componentWillUnmount this))))
+              (when componentWillUnmount (componentWillUnmount this)))
             (gobj/set this "fulcro$mounted" false)
             (drop-component! this)))))
    (wrap-this

--- a/src/main/com/fulcrologic/fulcro/raw/application.cljc
+++ b/src/main/com/fulcrologic/fulcro/raw/application.cljc
@@ -207,6 +207,7 @@
   "
   ([] (fulcro-app {}))
   ([{:keys [props-middleware
+            component-will-unmount-middleware
             global-eql-transform
             global-error-action
             default-result-action!
@@ -241,29 +242,30 @@
                                                         :external-config         external-config
                                                         :query-transform-default query-transform-default
                                                         :load-mutation           load-mutation}
-      :com.fulcrologic.fulcro.application/algorithms   {:com.fulcrologic.fulcro.algorithm/tx!                    tx!
-                                                        :com.fulcrologic.fulcro.algorithm/abort!                 (or abort-transaction! txn/abort!)
-                                                        :com.fulcrologic.fulcro.algorithm/batch-notifications    batch-notifications
-                                                        :com.fulcrologic.fulcro.algorithm/core-render!           (or core-render! identity)
-                                                        :com.fulcrologic.fulcro.algorithm/optimized-render!      (or optimized-render! identity)
-                                                        :com.fulcrologic.fulcro.algorithm/initialize-state!      initialize-state!
-                                                        :com.fulcrologic.fulcro.algorithm/shared-fn              shared-fn
-                                                        :com.fulcrologic.fulcro.algorithm/render-root!           render-root!
-                                                        :com.fulcrologic.fulcro.algorithm/hydrate-root!          hydrate-root!
-                                                        :com.fulcrologic.fulcro.algorithm/unmount-root!          unmount-root!
-                                                        :com.fulcrologic.fulcro.algorithm/refresh-component!     refresh-component!
-                                                        :com.fulcrologic.fulcro.algorithm/render!                render!
-                                                        :com.fulcrologic.fulcro.algorithm/remote-error?          (or remote-error? default-remote-error?)
-                                                        :com.fulcrologic.fulcro.algorithm/global-error-action    global-error-action
-                                                        :com.fulcrologic.fulcro.algorithm/merge*                 merge/merge*
-                                                        :com.fulcrologic.fulcro.algorithm/default-result-action! (or default-result-action! mut/default-result-action!)
-                                                        :com.fulcrologic.fulcro.algorithm/global-eql-transform   (or global-eql-transform default-global-eql-transform)
-                                                        :com.fulcrologic.fulcro.algorithm/index-root!            indexing/index-root!
-                                                        :com.fulcrologic.fulcro.algorithm/index-component!       indexing/index-component!
-                                                        :com.fulcrologic.fulcro.algorithm/drop-component!        indexing/drop-component!
-                                                        :com.fulcrologic.fulcro.algorithm/props-middleware       props-middleware
-                                                        :com.fulcrologic.fulcro.algorithm/render-middleware      render-middleware
-                                                        :com.fulcrologic.fulcro.algorithm/schedule-render!       schedule-render!}
+      :com.fulcrologic.fulcro.application/algorithms   {:com.fulcrologic.fulcro.algorithm/tx!                               tx!
+                                                        :com.fulcrologic.fulcro.algorithm/abort!                            (or abort-transaction! txn/abort!)
+                                                        :com.fulcrologic.fulcro.algorithm/batch-notifications               batch-notifications
+                                                        :com.fulcrologic.fulcro.algorithm/core-render!                      (or core-render! identity)
+                                                        :com.fulcrologic.fulcro.algorithm/optimized-render!                 (or optimized-render! identity)
+                                                        :com.fulcrologic.fulcro.algorithm/initialize-state!                 initialize-state!
+                                                        :com.fulcrologic.fulcro.algorithm/shared-fn                         shared-fn
+                                                        :com.fulcrologic.fulcro.algorithm/render-root!                      render-root!
+                                                        :com.fulcrologic.fulcro.algorithm/hydrate-root!                     hydrate-root!
+                                                        :com.fulcrologic.fulcro.algorithm/unmount-root!                     unmount-root!
+                                                        :com.fulcrologic.fulcro.algorithm/refresh-component!                refresh-component!
+                                                        :com.fulcrologic.fulcro.algorithm/render!                           render!
+                                                        :com.fulcrologic.fulcro.algorithm/remote-error?                     (or remote-error? default-remote-error?)
+                                                        :com.fulcrologic.fulcro.algorithm/global-error-action               global-error-action
+                                                        :com.fulcrologic.fulcro.algorithm/merge*                            merge/merge*
+                                                        :com.fulcrologic.fulcro.algorithm/default-result-action!            (or default-result-action! mut/default-result-action!)
+                                                        :com.fulcrologic.fulcro.algorithm/global-eql-transform              (or global-eql-transform default-global-eql-transform)
+                                                        :com.fulcrologic.fulcro.algorithm/index-root!                       indexing/index-root!
+                                                        :com.fulcrologic.fulcro.algorithm/index-component!                  indexing/index-component!
+                                                        :com.fulcrologic.fulcro.algorithm/drop-component!                   indexing/drop-component!
+                                                        :com.fulcrologic.fulcro.algorithm/props-middleware                  props-middleware
+                                                        :com.fulcrologic.fulcro.algorithm/render-middleware                 render-middleware
+                                                        :com.fulcrologic.fulcro.algorithm/component-will-unmount-middleware component-will-unmount-middleware
+                                                        :com.fulcrologic.fulcro.algorithm/schedule-render!                  schedule-render!}
       :com.fulcrologic.fulcro.application/runtime-atom (atom
                                                          {:com.fulcrologic.fulcro.application/app-root            nil
                                                           :com.fulcrologic.fulcro.application/mount-node          nil

--- a/src/main/com/fulcrologic/fulcro/specs.cljc
+++ b/src/main/com/fulcrologic/fulcro/specs.cljc
@@ -121,6 +121,7 @@
 (>def :com.fulcrologic.fulcro.algorithm/drop-component! ifn?)
 (>def :com.fulcrologic.fulcro.algorithm/props-middleware (s/nilable ifn?))
 (>def :com.fulcrologic.fulcro.algorithm/render-middleware (s/nilable ifn?))
+(>def :com.fulcrologic.fulcro.algorithm/component-will-unmount-middleware (s/nilable ifn?))
 
 (>def :com.fulcrologic.fulcro.application/algorithms
   (s/keys
@@ -137,6 +138,7 @@
           :com.fulcrologic.fulcro.algorithm/optimized-render!
           :com.fulcrologic.fulcro.algorithm/global-error-action
           :com.fulcrologic.fulcro.algorithm/props-middleware
+          :com.fulcrologic.fulcro.algorithm/component-will-unmount-middleware
           :com.fulcrologic.fulcro.algorithm/render-middleware
           :com.fulcrologic.fulcro.algorithm/shared-fn]))
 


### PR DESCRIPTION
This option allows wrapping `componentWillUnmount` calls created by `defsc`
class components, which allows for performing arbitrary component cleanup
across an entire fulcro application without needing to create a `defsc` wrapper
macro.

I'm working on a rendering library integration with fulcro which requires performing cleanup for every component in the application.
Not having this middleware currently means I have to copy the defsc implementation from the components namespace (and copy many of its helper functions which are private), which would all go away with this helper.