### PR TITLE
Accept list in addition to vectors for to-many join values

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/merge.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/merge.cljc
@@ -128,15 +128,15 @@
                   (assoc result jk ::not-found)
 
                   ; to-many join
-                  (and join? (vector? (get result jk)))
+                  (and join? (sequential? (get result jk)))
                   (assoc result jk (mapv (fn [item] (mark-missing-impl item (util/join-value element))) (get result jk)))
 
                   ; to-one join
                   (and join? (map? (get result jk)))
                   (assoc result jk (mark-missing-impl (get result jk) (util/join-value element)))
 
-                  ; join, but with a broken result (scalar instead of a map or vector)
-                  (and join? (vector? (util/join-value element)) (not (or (map? result-value) (vector? result-value))))
+                  ; join, but with a broken result (scalar instead of a map or sequence)
+                  (and join? (vector? (util/join-value element)) (not (or (map? result-value) (sequential? result-value))))
                   (assoc result result-key (mark-missing-impl {} (util/join-value element)))
 
                   ; prop we found, but not a further join...mark it as a leaf so sweep can stop early on it

--- a/src/test/com/fulcrologic/fulcro/algorithms/merge_spec.cljc
+++ b/src/test/com/fulcrologic/fulcro/algorithms/merge_spec.cljc
@@ -340,6 +340,15 @@
                         :number          "98765-4321"
                         :ui/initial-flag :start}}}
 
+    "Doesn't mark a to-many attribute value that is a list as missing"
+    (merge/merge-component {} MPersonPM (person :mary "Mary" (list (phone-number 55 "98765-4321"))) :remove-missing? true)
+    => {:person/id {:mary {:id      :mary
+                           :name    "Mary"
+                           :numbers [[:phone/id 55]]}}
+        :phone/id  {55 {:id              55
+                        :number          "98765-4321"
+                        :ui/initial-flag :start}}}
+
     "Can assign IDs to primary entities via pre-merge"
     (merge/merge-component {} MPersonPM {:name "Mary2" :numbers [{:number "98765-4321"}]}
       :replace [:global-ref])


### PR DESCRIPTION
Problem
-------

If a resolver returns a lazy list inside the value, as in `{:friends (filter friend? people)}` then this will be transmitted as a list and finally considered an invalid join value and replaced with `{}`.

This repeatedly trips people. They see they are returning data from the backend, even see it in the brower's Network tab, but client DB ends up just with `{}` and they have no idea why the data disappeared. Noticing that they are actually returning a (lazy) list and that they should be returning a vector is not simple.

Solution space
--------------

1. We could log a warning. That would hopefully make it far easier to troubleshoot the problem, even if people keep running into it.
2. Ask Pathom or Fulcro's Transit integration to turn all lists into vectors automatically. Cons: it does not really seem that the solution belongs there since the problem is inside `merge`.
3. Accept `sequential?` instead of just `vector?`, thus making it work seamlessly (it gets later converted to a vector anyway). Pros: Simple change, user friendly. Cons: Possible unintended consequences???

Opted for 3. as Tony sees the risk as acceptable and it is the cleanest and most user-friendly solution.