### PR TITLE
defmutation: document error-action

### DIFF
--- a/src/main/com/fulcrologic/fulcro/mutations.cljc
+++ b/src/main/com/fulcrologic/fulcro/mutations.cljc
@@ -490,11 +490,12 @@
        \"docstring\" [params-map]
        (action [env] ...)
        (ok-action [env] ...)
+       (error-action [env] ...)
        (result-action [env] ((-> env :handlers :ok-action) env)))
      ```
 
      This macro normally adds a `:result-action` handler that does normal Fulcro mutation remote result logic unless
-     you supply your own.
+     you supply your own. The default result-action ends up invoking either `ok-action` or `error-action`.
 
      Remotes in Fulcro 3 are also lambdas, and are called with an `env` that contains the state as it exists *after*
      the `:action` has run in `state`, but also include the 'before action state' as a map in `:state-before-action`.


### PR DESCRIPTION
Extend the docstring to mention that error-action exists too.

I tend to rely on Fulcro's docstring and in repeatedly confuses me that this one doesn't mention error-action, that it only is described in the Book. This change fixes that.