### PR TITLE
fix: ensure removing source works with app-state path

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/data_targeting.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/data_targeting.cljc
@@ -5,6 +5,7 @@
     [clojure.spec.alpha :as s]
     [com.fulcrologic.guardrails.core :as gw :refer [>defn => >def]]
     [edn-query-language.core :as eql]
+    [taoensso.encore :as enc]
     [taoensso.timbre :as log]))
 
 (>def ::target vector?)
@@ -153,4 +154,10 @@
                          (log/warn "Target processing found an unsupported case. See https://book.fulcrologic.com/#warn-target-unsuported-case")
                          state-map))))]
      (cond-> (process-target-impl state-map source-path target)
-       (and remove-source? (not (eql/ident? source-path))) (dissoc source-path)))))
+       (and remove-source?
+            (keyword? source-path))
+       (dissoc source-path)
+       (and remove-source?
+           (not (eql/ident? source-path))
+           (vector? source-path))
+       (enc/dissoc-in source-path)))))


### PR DESCRIPTION
when the source-path isn't an ident and `remove-source?` is true, the expected behavior of targeting/process target is to remove the thing at the `source-path` from the app-state.
`dissoc` will not work with an app-state path.