### PR TITLE
react18: assoc reactRoot to fulcro app

### DIFF
--- a/src/main/com/fulcrologic/fulcro/react/version18.cljc
+++ b/src/main/com/fulcrologic/fulcro/react/version18.cljc
@@ -24,14 +24,15 @@
   [app]
   #?(:cljs (let [reactRoot (volatile! nil)]
              (-> app
-               (assoc-in
-                 [:com.fulcrologic.fulcro.application/algorithms :com.fulcrologic.fulcro.algorithm/render-root!]
-                 (fn [ui-root mount-node]
-                   (when-not @reactRoot
-                     (vreset! reactRoot (dom-client/createRoot mount-node)))
-                   (.render ^js @reactRoot ui-root)
-                   @reactRoot))
-               (assoc-in
-                 [:com.fulcrologic.fulcro.application/algorithms :com.fulcrologic.fulcro.algorithm/hydrate-root!]
-                 (fn [ui-root mount-node] (dom-client/hydrateRoot mount-node ui-root)))))
+                 (assoc ::reactRoot reactRoot)
+                 (assoc-in
+                  [:com.fulcrologic.fulcro.application/algorithms :com.fulcrologic.fulcro.algorithm/render-root!]
+                  (fn [ui-root mount-node]
+                    (when-not @reactRoot
+                      (vreset! reactRoot (dom-client/createRoot mount-node)))
+                    (.render ^js @reactRoot ui-root)
+                    @reactRoot))
+                 (assoc-in
+                  [:com.fulcrologic.fulcro.application/algorithms :com.fulcrologic.fulcro.algorithm/hydrate-root!]
+                  (fn [ui-root mount-node] (dom-client/hydrateRoot mount-node ui-root)))))
      :clj  app))


### PR DESCRIPTION
I haven't seen any way to grab the react 18 root from a mounted fulcro app, so here it is.