### PR TITLE
Fix ident & link queries when target value is `false`

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/denormalize.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/denormalize.cljc
@@ -61,9 +61,10 @@
   (reduce
     (fn [n {:keys [key]}]
       (if (lookup-ref? key)
-        (if-let [x (follow-ref state-map key)]
-          (assoc! n (ref-key key) x)
-          n)
+        (let [x (follow-ref state-map key)]
+          (if (some? x)
+            (assoc! n (ref-key key) x)
+            n))
         (if-let [entry (and (coll? entity) (find entity key))]
           (assoc! n key (second entry))
           n)))

--- a/src/test/com/fulcrologic/fulcro/algorithms/denormalize_spec.cljc
+++ b/src/test/com/fulcrologic/fulcro/algorithms/denormalize_spec.cljc
@@ -140,6 +140,12 @@
       {:point {123 {:bar "baz" :extra "data"}}})
     => {:entry {[:point 123] {:bar "baz", :extra "data"}}}
 
+    "ident query with `false` value"
+    (verify-db->tree [{:entry [[:point 456]]}]
+                     {:entry {:data "foo"}}
+      {:point {456 false}})
+    => {:entry {[:point 456] false}}
+
     "ident join"
     (verify-db->tree [{[:point 123] [:bar]}]
       {:entry {:data "foo"}}
@@ -190,6 +196,13 @@
       {:x 22}
       {:root/value {:a 1 :b 2}})
     => {:root/value {:a 1}}
+
+    "link query with `false` value"
+    (denorm/db->tree
+      [[:root/value '_]]
+      {}
+      {:root/value false})
+    => {:root/value false}
 
     "wildcard"
     (verify-db->tree


### PR DESCRIPTION
Resolves #543 