### PR TITLE
Mark render-to-str deprecated, show how to do it yourself

### DIFF
--- a/src/main/com/fulcrologic/fulcro/dom.cljs
+++ b/src/main/com/fulcrologic/fulcro/dom.cljs
@@ -71,8 +71,14 @@
   [component el]
   (react.dom/render component el))
 
-(defn render-to-str
-  "Equivalent to React.renderToString. NOTE: You must make sure js/ReactDOMServer is defined (e.g. require cljsjs.react.dom.server) to use this function."
+(defn ^:deprecated render-to-str
+  "This fn is outdated - it expects js/ReactDOMServer to be defined (used to be provided cljsjs.react.dom.server).
+  It is better to do it yourself (under shadow-cljs):
+   
+   ```clj
+   (ns ex (:require [\"react-dom/server\" :as react-dom-server] ...))
+   (react-dom-server/renderToString c)
+   ```"
   [c]
   (js/ReactDOMServer.renderToString c))
 


### PR DESCRIPTION
Use proper require of react-dom/server and invoke its renderToString, instead of accessing the global js/ReactDOMServer, which might not be available.

I had troubles making sure that `js/ReactDOMServer` and thus couldn't render to a string. With this change, it works fine.

**BEWARE**: I don't know whether the use of js/ReactDOMServer is a left-over from old times, or whether it is intentional, e.g. to make sure that we do not require `react-dom/server` if not needed. So I don't know whether this change is desirable or not.