### PR TITLE
Improve error message when a map passed by mistake as a child to fragment

### DIFF
--- a/src/main/com/fulcrologic/fulcro/components.cljc
+++ b/src/main/com/fulcrologic/fulcro/components.cljc
@@ -1020,7 +1020,9 @@
                           [{} args])]
        (vec children))
      :cljs
-     (let [[props children] (if (map? (first args))
+     (let [[props children] (if (and (map? (first args))
+                                     ;; fragment only supports key,children
+                                     (= ["key"] (->> args first keys (map name))))
                               [(first args) (rest args)]
                               [#js {} args])]
        (apply react/createElement react/Fragment (clj->js props) (force-children children)))))


### PR DESCRIPTION
... or to ErrorBoundary (which uses comp/fragment).

Without this change, we assume the map is props, and end up getting a _warning_ like "Warning: Invalid prop `some-prop...` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props."

With this change, we get a proper _error_ about trying to render the wrong type, and in which component.