### PR TITLE
df/load! properly handles components with a union query

### DIFF
--- a/src/main/com/fulcrologic/fulcro/data_fetch.cljc
+++ b/src/main/com/fulcrologic/fulcro/data_fetch.cljc
@@ -70,7 +70,12 @@
   "Remove items from a query when the query element where the (node-predicate key) returns true. Commonly used with
    a set as a predicate to elide specific well-known UI-only paths."
   [query node-predicate]
-  (-> query eql/query->ast (elide-ast-nodes node-predicate) eql/ast->query))
+  (-> query
+      (as-> <> [{::temp-root <>}])
+      eql/query->ast
+      (elide-ast-nodes node-predicate)
+      eql/ast->query
+      (get-in [0 ::temp-root])))
 
 (defn load-params*
   "Internal function to validate and process the parameters of `load` and `load-action`."


### PR DESCRIPTION
df/load! was altering component queries and making them invalid when
they were a union query at the top level component. More info can be
found in #556.

This commit wraps the component query in a temporary top level root
query before eliding attributes provided by the without option, which is
what was causing the problem.