### PR TITLE
'|' is not permit for filename in Windows

### DIFF
--- a/src/main/com/fulcrologic/fulcro/networking/file_upload.clj
+++ b/src/main/com/fulcrologic/fulcro/networking/file_upload.clj
@@ -30,7 +30,7 @@
   (try
     (let [ast             (eql/query->ast txn)
           mutation->files (reduce (fn [result {:keys [filename] :as file}]
-                                    (enc/if-let [[mutation-name filename] (some-> filename (str/split #"[|]"))
+                                    (enc/if-let [[mutation-name filename] (some-> filename (str/split #"[%]"))
                                                  mutation-sym (some-> mutation-name (edn/read-string))]
                                       (update result mutation-sym (fnil conj []) (assoc file :filename filename))
                                       (do

--- a/src/main/com/fulcrologic/fulcro/networking/file_upload.cljs
+++ b/src/main/com/fulcrologic/fulcro/networking/file_upload.cljs
@@ -112,7 +112,7 @@
            (doseq [{:keys [dispatch-key params]} (:children ast)]
              (when-let [uploads (::uploads params)]
                (doseq [{:file/keys [name content content-type]} uploads]
-                 (let [name-with-mutation (str dispatch-key "|" name)
+                 (let [name-with-mutation (str dispatch-key "%" name)
                        js-value           (-> content meta :js-value)
                        content            (some-> js-value (js-value->uploadable-object content-type))]
                    (.append form "files" content name-with-mutation)))))


### PR DESCRIPTION
Hi, I found that using the '|' character in file-upload caused issues on Windows, as it's not allowed in filenames. I replaced it with %, and my code works (I test it in both Debian and Windows). Is the char just used internally and the change will not break other piece of code?