### PR TITLE
Fix CI: GitHub `actions/cache@v2` -> ` actions/cache@v4` and `clj-doc` exclusion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           tools-deps: '1.10.3.1040'
       - name: Cache All The Things
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,7 @@ dev:
 deploy:
 	rm -rf target
 	mvn deploy
+
+check-clj-doc:
+	clojure -T:build jar
+	clojure -T:check-clj-doc analyze-local

--- a/deps.edn
+++ b/deps.edn
@@ -41,4 +41,7 @@
                                       org.clojure/tools.namespace       {:mvn/version "1.0.0"}}}
 
            :build      {:deps       {io.github.seancorfield/build-clj {:tag "v0.6.7" :sha "22c2d09"}}
-                        :ns-default build}}}
+                        :ns-default build}
+
+           :check-clj-doc {:deps {io.github.cljdoc/cljdoc-analyzer {:tag "v1.0.802" :sha "911656c5"}}
+                           :ns-default cljdoc-analyzer.deps-tool}}}

--- a/src/main/com/fulcrologic/fulcro/inspect/target_impl.cljc
+++ b/src/main/com/fulcrologic/fulcro/inspect/target_impl.cljc
@@ -1,4 +1,4 @@
-(ns com.fulcrologic.fulcro.inspect.target-impl
+(ns ^:no-doc com.fulcrologic.fulcro.inspect.target-impl
   (:require
     [clojure.core.async :as async]
     [com.fulcrologic.devtools.common.built-in-mutations :as bi]


### PR DESCRIPTION
- Deprecation notice for `actions/cache@v2`: https://github.com/actions/toolkit/discussions/1890
- Add `make-clj-doc` and fix `analyze-local`