### PR TITLE
Add `args` parameter to `use-imperative-handle` for dependency management

### DIFF
--- a/src/main/com/fulcrologic/fulcro/react/hooks.cljc
+++ b/src/main/com/fulcrologic/fulcro/react/hooks.cljc
@@ -116,9 +116,11 @@
 (defn use-imperative-handle
   "A simple wrapper around React/useImperativeHandle.
 
-  React docs: https://reactjs.org/docs/hooks-reference.html#useimperativehandle"
-  [ref f]
-  #?(:cljs (react/useImperativeHandle ref f)))
+  React docs: https://react.dev/reference/react/useImperativeHandle"
+  ([ref f]
+   #?(:cljs (react/useImperativeHandle ref f)))
+  ([ref f args]
+   #?(:cljs (react/useImperativeHandle ref f (to-array args)))))
 
 (defn use-layout-effect
   "A simple wrapper around React/useLayoutEffect.


### PR DESCRIPTION
Cause:
The current implementation of use-imperative-handle is missing the args parameter, which is similar in behavior to the dependency array in use-effect. Without this parameter, updates to dependencies are not tracked, potentially causing stale references and unexpected behavior.

Fix:
Added an args parameter to the use-imperative-handle implementation, enabling dependency tracking and ensuring the function updates correctly when dependencies change. This aligns its behavior with other React hooks like use-effect.