### PR TITLE
Improve the formatting in the docstring of db->tree

### DIFF
--- a/src/main/com/fulcrologic/fulcro/algorithms/denormalize.cljc
+++ b/src/main/com/fulcrologic/fulcro/algorithms/denormalize.cljc
@@ -215,9 +215,9 @@
 (defn db->tree
   "Pull a tree of data from a fulcro normalized database as a tree corresponding to the given query.
 
-  query - EQL.
-  starting-entity - A map of data or ident at which to start.
-  state-map - The overall normalized database from which idents can be resolved.
+  - `query` - EQL.
+  - `starting-entity` - A map of data or ident at which to start.
+  - `state-map` - The overall normalized database from which idents can be resolved.
 
   Returns a tree of data where each resolved data node is also marked with the current
   *denormalize-time* (dynamically bound outside of this call). Users of this function that


### PR DESCRIPTION
Added bullet points and backticks, so that the docstring of `db->tree` is nicely formatted when it is rendered in an IDE. 

Inspired by the docstring of `merge*`.
